### PR TITLE
(refactor): use cacheRoot path constant

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,5 +11,8 @@ export const paths = {
   appDist: resolveApp('dist'),
   appConfig: resolveApp('tsdx.config.js'),
   jestConfig: resolveApp('jest.config.js'),
-  progressEstimatorCache: resolveApp('node_modules/.cache/.progress-estimator'),
+  cacheRoot: resolveApp('node_modules/.cache/tsdx'),
+  progressEstimatorCache: resolveApp(
+    'node_modules/.cache/tsdx/.progress-estimator'
+  ),
 };

--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -1,5 +1,6 @@
 import { safeVariableName, safePackageName, external } from './utils';
 import { paths } from './constants';
+import path from 'path';
 import { RollupOptions } from 'rollup';
 import { terser } from 'rollup-plugin-terser';
 import { DEFAULT_EXTENSIONS } from '@babel/core';
@@ -145,7 +146,7 @@ export async function createRollupConfig(
       },
       typescript({
         typescript: ts,
-        cacheRoot: `./node_modules/.cache/tsdx/${opts.format}/`,
+        cacheRoot: path.join(paths.cacheRoot, opts.format),
         tsconfig: opts.tsconfig,
         tsconfigDefaults: {
           exclude: [


### PR DESCRIPTION
- and put progressEstimatorCache into the TSDX cache dir too

Noticed in #249 that this was used before my #329 , so should standardize usage of both