### PR TITLE
Update help channels to point to formium org

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "author": "Jared Palmer <jared@palmer.net>",
   "description": "Zero-config TypeScript package development",
   "license": "MIT",
-  "homepage": "https://github.com/jaredpalmer/tsdx",
+  "homepage": "https://github.com/formium/tsdx",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jaredpalmer/tsdx.git"
+    "url": "git+https://github.com/formium/tsdx.git"
   },
   "keywords": [
     "react",
@@ -16,7 +16,7 @@
     "rollup"
   ],
   "bugs": {
-    "url": "https://github.com/jaredpalmer/tsdx/issues"
+    "url": "https://github.com/formium/tsdx/issues"
   },
   "bin": {
     "tsdx": "./dist/index.js"

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -11,7 +11,7 @@ export const help = function() {
   return `
     Only ${chalk.green('<project-directory>')} is required.
     If you have any problems, do not hesitate to file an issue:
-      ${chalk.cyan('https://github.com/formik/tsdx/issues/new')}
+    ${chalk.cyan('https://github.com/formium/tsdx/issues/new')}
   `;
 };
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -86,7 +86,7 @@ export const start = async function(projectName: string) {
     ${Output.cmd(commands.test)}
     
   Questions? Feedback? Please let me know!
-  ${chalk.green('https://github.com/formik/tsdx/issues')}
+  ${chalk.green('https://github.com/formium/tsdx/issues')}
 `;
 };
 


### PR DESCRIPTION
Currently, the URLs pointing to the repo/issues are not uniform or correct.
It's not a huge deal since it seems all redirects are current working correctly,
but consistency is nice
