### PR TITLE
Fix formatting and lint errors from previous PRs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -481,9 +481,7 @@ function setAuthorName(author: string) {
 
 prog
   .command('test')
-  .describe(
-    'Run jest test runner. Passes through all flags directly to Jest'
-  )
+  .describe('Run jest test runner. Passes through all flags directly to Jest')
   .action(async (opts: { config?: string }) => {
     // Do this as the first thing so that any code reading it knows the right env.
     process.env.BABEL_ENV = 'test';

--- a/website/components/video.js
+++ b/website/components/video.js
@@ -1,4 +1,4 @@
-import { useRef, useCallback, useEffect } from 'react';
+import React, { useRef, useCallback, useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 import 'intersection-observer';
 

--- a/website/components/video.js
+++ b/website/components/video.js
@@ -1,52 +1,52 @@
-import { useRef, useCallback, useEffect } from 'react'
-import { useInView } from 'react-intersection-observer'
-import 'intersection-observer'
+import { useRef, useCallback, useEffect } from 'react';
+import { useInView } from 'react-intersection-observer';
+import 'intersection-observer';
 
 export default ({ src, caption, ratio }) => {
   const [inViewRef, inView] = useInView({
     threshold: 1,
-  })
-  const videoRef = useRef()
+  });
+  const videoRef = useRef();
 
   const setRefs = useCallback(
-    (node) => {
+    node => {
       // Ref's from useRef needs to have the node assigned to `current`
-      videoRef.current = node
+      videoRef.current = node;
       // Callback refs, like the one from `useInView`, is a function that takes the node as an argument
-      inViewRef(node)
+      inViewRef(node);
 
       if (node) {
-        node.addEventListener('click', function () {
+        node.addEventListener('click', function() {
           if (this.paused) {
-            this.play()
+            this.play();
           } else {
-            this.pause()
+            this.pause();
           }
-        })
+        });
       }
     },
     [inViewRef]
-  )
+  );
 
   useEffect(() => {
     if (!videoRef || !videoRef.current) {
-      return
+      return;
     }
 
     if (inView) {
-      videoRef.current.play()
+      videoRef.current.play();
     } else {
-      videoRef.current.pause()
+      videoRef.current.pause();
     }
-  }, [inView])
+  }, [inView]);
 
   return (
     <figure>
-      <div style={{ paddingBottom: ratio * 100 + '%' }}/>
+      <div style={{ paddingBottom: ratio * 100 + '%' }} />
       <video loop muted autoPlay playsInline ref={setRefs}>
         <source src={src} type="video/mp4" />
       </video>
       {caption && <figcaption>{caption}</figcaption>}
     </figure>
-  )
-}
+  );
+};

--- a/website/nextra.config.js
+++ b/website/nextra.config.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Logo } from 'components/logo';
 
 export default {
@@ -67,7 +68,7 @@ export default {
         <a
           href="https://jaredpalmer.com/?utm_source=tsdx"
           target="_blank"
-          rel="noopener"
+          rel="noopener noreferrer"
           className="inline-flex items-center no-underline text-current font-semibold"
         >
           <span className="mr-1">A Jared Palmer Project</span>
@@ -80,7 +81,7 @@ export default {
             filepath
           }
           target="_blank"
-          rel="noopener"
+          rel="noopener noreferrer"
         >
           Edit this page on GitHub
         </a>

--- a/website/pages/_app.js
+++ b/website/pages/_app.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import '.nextra/styles.css';
 import GoogleFonts from 'next-google-fonts';
 

--- a/website/pages/_app.js
+++ b/website/pages/_app.js
@@ -1,5 +1,5 @@
-import '.nextra/styles.css'
-import GoogleFonts from 'next-google-fonts'
+import '.nextra/styles.css';
+import GoogleFonts from 'next-google-fonts';
 
 export default function Nextra({ Component, pageProps }) {
   return (
@@ -10,5 +10,5 @@ export default function Nextra({ Component, pageProps }) {
       />
       <Component {...pageProps} />
     </>
-  )
+  );
 }

--- a/website/pages/_document.js
+++ b/website/pages/_document.js
@@ -1,6 +1,6 @@
-import React from 'react'
-import Document, { Html, Head, Main, NextScript } from 'next/document'
-import { SkipNavLink } from '@reach/skip-nav'
+import React from 'react';
+import Document, { Html, Head, Main, NextScript } from 'next/document';
+import { SkipNavLink } from '@reach/skip-nav';
 
 class MyDocument extends Document {
   render() {
@@ -18,8 +18,8 @@ class MyDocument extends Document {
           />
         </body>
       </Html>
-    )
+    );
   }
 }
 
-export default MyDocument
+export default MyDocument;

--- a/website/postcss.config.js
+++ b/website/postcss.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  plugins: ['tailwindcss', 'postcss-preset-env']
-}
+  plugins: ['tailwindcss', 'postcss-preset-env'],
+};

--- a/website/tailwind.config.js
+++ b/website/tailwind.config.js
@@ -1,5 +1,11 @@
 module.exports = {
-  purge: ['./components/**/*.js', './pages/**/*.md', './pages/**/*.mdx', './.nextra/**/*.js', './nextra.config.js'],
+  purge: [
+    './components/**/*.js',
+    './pages/**/*.md',
+    './pages/**/*.mdx',
+    './.nextra/**/*.js',
+    './nextra.config.js',
+  ],
   theme: {
     screens: {
       sm: '640px',
@@ -11,7 +17,7 @@ module.exports = {
       display: ['inter', 'sans-serif'],
     },
     letterSpacing: {
-      tight: '-0.015em'
-    }
-  }
-}
+      tight: '-0.015em',
+    },
+  },
+};


### PR DESCRIPTION
## Description

### Commits

#### format: auto-fix help dialog formatting error
- with `yarn lint --fix`

- formatting error is from 8b148ce

#### format: auto-fix new website formatting errors
- with `yarn lint --fix`

- formatting errors are from b09e195

#### lint: manually fix new website ESLint errors and warnings
- these were unable to be auto-fixed, so I had to manually fix them

- lint errors are from b09e195

## Tags

One is from #734, the rest are from #765 .

This was causing CI errors for basically every PR afterward, mentioned in https://github.com/formium/tsdx/pull/762#pullrequestreview-450003239 and #789 

## Review Notes

Not sure why `nextra` has some of these lint errors built into their examples (lack of `React`, `noreferrer`, etc), though [the project](https://github.com/shuding/nextra) does explicitly say that it is not production ready. Perhaps worth an upstream PR or two.

I plan to merge this myself, but in case someone else decides to beforehand, please ensure to **rebase** (_not_ squash merge) the changes in as they're intentionally 3 separate commits. 