### PR TITLE
update react-with-storybook template for Storybook v6

### DIFF
--- a/src/templates/react-with-storybook.ts
+++ b/src/templates/react-with-storybook.ts
@@ -6,16 +6,13 @@ const storybookTemplate: Template = {
   dependencies: [
     ...reactTemplate.dependencies,
     '@babel/core',
-    '@storybook/addon-actions',
+    '@storybook/addon-essentials',
     '@storybook/addon-links',
     '@storybook/addon-info',
-    '@storybook/addon-docs',
     '@storybook/addons',
     '@storybook/react',
-    'react-docgen-typescript-loader',
     'react-is',
     'babel-loader',
-    'ts-loader',
   ],
   name: 'react-with-storybook',
   packageJson: {

--- a/templates/react-with-storybook/.storybook/main.js
+++ b/templates/react-with-storybook/.storybook/main.js
@@ -1,4 +1,4 @@
 module.exports = {
-  stories: ['../stories/**/*.stories.@(ts|tsx)'],
-  addons: ['@storybook/addon-essentials', '@storybook/addon-links'],
+  stories: ['../stories/**/*.stories.@(ts|tsx|js|jsx)'],
+  addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
 };

--- a/templates/react-with-storybook/.storybook/main.js
+++ b/templates/react-with-storybook/.storybook/main.js
@@ -1,24 +1,4 @@
 module.exports = {
-  stories: ['../stories/**/*.stories.(ts|tsx)'],
-  addons: ['@storybook/addon-actions', '@storybook/addon-links', '@storybook/addon-docs'],
-  webpackFinal: async (config) => {
-    config.module.rules.push({
-      test: /\.(ts|tsx)$/,
-      use: [
-        {
-          loader: require.resolve('ts-loader'),
-          options: {
-            transpileOnly: true,
-          },
-        },
-        {
-          loader: require.resolve('react-docgen-typescript-loader'),
-        },
-      ],
-    });
-
-    config.resolve.extensions.push('.ts', '.tsx');
-
-    return config;
-  },
+  stories: ['../stories/**/*.stories.@(ts|tsx)'],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-links'],
 };

--- a/templates/react-with-storybook/.storybook/preview.js
+++ b/templates/react-with-storybook/.storybook/preview.js
@@ -1,0 +1,3 @@
+export const parameters = {
+  actions: { argTypesRegex: '^on.*' },
+};

--- a/templates/react-with-storybook/.storybook/preview.js
+++ b/templates/react-with-storybook/.storybook/preview.js
@@ -1,3 +1,5 @@
+// https://storybook.js.org/docs/react/writing-stories/parameters#global-parameters
 export const parameters = {
+  // https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args
   actions: { argTypesRegex: '^on.*' },
 };

--- a/templates/react-with-storybook/README.md
+++ b/templates/react-with-storybook/README.md
@@ -71,7 +71,7 @@ This is the folder structure we set up for you:
 /test
   blah.test.tsx   # EDIT THIS
 /stories
-  Thing.stories.tsx
+  Thing.stories.tsx #EDIT THIS
 /.storybook
   main.js
 .gitignore

--- a/templates/react-with-storybook/README.md
+++ b/templates/react-with-storybook/README.md
@@ -70,6 +70,10 @@ This is the folder structure we set up for you:
   index.tsx       # EDIT THIS
 /test
   blah.test.tsx   # EDIT THIS
+/stories
+  Thing.stories.tsx
+/.storybook
+  main.js
 .gitignore
 package.json
 README.md         # EDIT THIS

--- a/templates/react-with-storybook/README.md
+++ b/templates/react-with-storybook/README.md
@@ -71,9 +71,10 @@ This is the folder structure we set up for you:
 /test
   blah.test.tsx   # EDIT THIS
 /stories
-  Thing.stories.tsx #EDIT THIS
+  Thing.stories.tsx # EDIT THIS
 /.storybook
   main.js
+  preview.js
 .gitignore
 package.json
 README.md         # EDIT THIS

--- a/templates/react-with-storybook/src/index.tsx
+++ b/templates/react-with-storybook/src/index.tsx
@@ -1,11 +1,15 @@
 import React, { FC, HTMLAttributes, ReactChild } from 'react';
 
 export interface Props extends HTMLAttributes<HTMLDivElement> {
+  /** custom content, defaults to 'the snozzberries taste like snozzberries' */
   children?: ReactChild;
 }
 
 // Please do not use types off of a default export module or else Storybook Docs will suffer.
 // see: https://github.com/storybookjs/storybook/issues/9556
+/**
+ * A custom Thing component. Neat!
+ */
 export const Thing: FC<Props> = ({ children }) => {
   return <div>{children || `the snozzberries taste like snozzberries`}</div>;
 };

--- a/templates/react-with-storybook/stories/Thing.stories.tsx
+++ b/templates/react-with-storybook/stories/Thing.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Meta, Story } from '@storybook/react';
 import { Thing, Props } from '../src';
 
-export default {
+const meta: Meta = {
   title: 'Welcome',
   component: Thing,
   argTypes: {
@@ -15,7 +15,9 @@ export default {
   parameters: {
     controls: { expanded: true },
   },
-} as Meta;
+};
+
+export default meta;
 
 const Template: Story<Props> = args => <Thing {...args} />;
 

--- a/templates/react-with-storybook/stories/Thing.stories.tsx
+++ b/templates/react-with-storybook/stories/Thing.stories.tsx
@@ -1,10 +1,26 @@
 import React from 'react';
+import { Meta, Story } from '@storybook/react';
 import { Thing, Props } from '../src';
 
 export default {
   title: 'Welcome',
-};
+  component: Thing,
+  argTypes: {
+    children: {
+      control: {
+        type: 'text',
+      },
+    },
+  },
+  parameters: {
+    controls: { expanded: true },
+  },
+} as Meta;
 
-// By passing optional props to this story, you can control the props of the component when
-// you consume the story in a test.
-export const Default = (props?: Partial<Props>) => <Thing {...props} />;
+const Template: Story<Props> = args => <Thing {...args} />;
+
+// By passing using the Args format for exported stories, you can control the props for a component for reuse in a test
+// https://storybook.js.org/docs/react/workflows/unit-testing
+export const Default = Template.bind({});
+
+Default.args = {};


### PR DESCRIPTION
With the release of [Storybook v6](https://storybook.js.org/releases/6.0), there are [updates to be made](https://storybook.js.org/releases/6.0) to migrate from v5.3 and allow the `react-with-storybook` template take advantage of the latest features, i.e. built-in Typescript support and new story format. 