### PR TITLE
Add support for custom .npmrc

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -241,7 +241,7 @@ prog
     const installSpinner = ora(Messages.installing(deps.sort())).start();
     try {
       const cmd = await getInstallCmd();
-      const args = getInstallArgs(cmd, deps).join(' ')
+      const args = getInstallArgs(cmd, deps).join(' ');
       await shell.exec(`${cmd} ${args}`, {
         silent: true,
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -241,7 +241,10 @@ prog
     const installSpinner = ora(Messages.installing(deps.sort())).start();
     try {
       const cmd = await getInstallCmd();
-      await execa(cmd, getInstallArgs(cmd, deps));
+      const args = getInstallArgs(cmd, deps).join(' ')
+      await shell.exec(`${cmd} ${args}`, {
+        silent: true,
+      });
       installSpinner.succeed('Installed dependencies');
       console.log(await Messages.start(pkg));
     } catch (error) {


### PR DESCRIPTION
I was building a modified version of TSDX (custom themes), and one of the issues I faced was that if templates had private packages, even though the template had a correct .npmrc the install step wouldn't pick it up and timeout, the solution was to use shelljs instead.

This would go hand in hand with https://github.com/formium/tsdx/pull/502 as well.