### PR TITLE
website/fix: extending configuration files urls

### DIFF
--- a/website/pages/customization.md
+++ b/website/pages/customization.md
@@ -73,12 +73,12 @@ module.exports = {
 
 ## Babel
 
-You can add your own `.babelrc` to the root of your project and TSDX will **merge** it with [its own Babel transforms](./src/babelPluginTsdx.ts) (which are mostly for optimization), putting any new presets and plugins at the end of its list.
+You can add your own `.babelrc` to the root of your project and TSDX will **merge** it with [its own Babel transforms](../../src/babelPluginTsdx.ts) (which are mostly for optimization), putting any new presets and plugins at the end of its list.
 
 ## Jest
 
-You can add your own `jest.config.js` to the root of your project and TSDX will **shallow merge** it with [its own Jest config](./src/createJestConfig.ts).
+You can add your own `jest.config.js` to the root of your project and TSDX will **shallow merge** it with [its own Jest config](../../src/createJestConfig.ts).
 
 ## ESLint
 
-You can add your own `.eslintrc.js` to the root of your project and TSDX will **deep merge** it with [its own ESLint config](./src/createEslintConfig.ts).
+You can add your own `.eslintrc.js` to the root of your project and TSDX will **deep merge** it with [its own ESLint config](../../src/createEslintConfig.ts).


### PR DESCRIPTION
The links to the example configuration files seem to have moved and were not working on the main website.