### PR TITLE
docs: update features and comparison with changes from past year

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ TSDX comes with the "battery-pack included" and is part of a complete TypeScript
 - Bundle size snapshots
 - Opt-in to extract `invariant` error codes
 - Jest test runner setup with sensible defaults via `tsdx test`
+- ESLint with Prettier setup with sensible defaults via `tsdx lint`
 - Zero-config, single dependency
+- Escape hatches for customization via `.babelrc.js`, `jest.config.js`, `.eslintrc.js`, and `tsdx.config.js`
 
 ## Quick Start
 
@@ -387,13 +389,18 @@ You can add your own `.eslintrc.js` to the root of your project and TSDX will **
 
 ## Inspiration
 
-TSDX is ripped out of [Formik's](https://github.com/jaredpalmer/formik) build tooling. TSDX is very similar to [@developit/microbundle](https://github.com/developit/microbundle), but that is because Formik's Rollup configuration and Microbundle's internals have converged around similar plugins over the last year or so.
+TSDX was originally ripped out of [Formik's](https://github.com/jaredpalmer/formik) build tooling.
+TSDX has several similarities to [@developit/microbundle](https://github.com/developit/microbundle), but that is because Formik's Rollup configuration and Microbundle's internals had converged around similar plugins.
 
 ### Comparison with Microbundle
 
+Some key differences include:
+
 - TSDX includes out-of-the-box test running via Jest
-- TSDX includes a bootstrap command and default package template
-- TSDX is 100% TypeScript focused
+- TSDX includes out-of-the-box linting and formatting via ESLint and Prettier
+- TSDX includes a bootstrap command with a few package templates
+- TSDX allows for some lightweight customization
+- TSDX is TypeScript focused, but also supports plain JavaScript
 - TSDX outputs distinct development and production builds (like React does) for CJS and UMD builds. This means you can include rich error messages and other dev-friendly goodies without sacrificing final bundle size.
 
 ## API Reference


### PR DESCRIPTION
## Description

- [`tsdx lint`](https://github.com/formium/tsdx/pull/99) is a thing now
- [`tsdx create`](https://github.com/formium/tsdx/commit/9010ecbda5121dba74c04edebd2b18ef447eda3e) is a thing
- [`tsdx.config.js`](https://github.com/formium/tsdx/pull/183) is a thing now

- "last year or so" in reference to microbundle is outdated now and the
  differences have grown since then, so be softer on the language of
  similarities
- TSDX now has good support for JS as well, I put in [a]((https://github.com/formium/tsdx/pull/474) good [bit](https://github.com/formium/tsdx/pull/486) of [work](https://github.com/formium/tsdx/pull/487)
  to make that possible, especially for gradual migrations and partial
  codebases
  - and some contributors [helped](https://github.com/formium/tsdx/pull/524) as well

## Tags

Lint added in #99
Create added in 9010ecbda5121dba74c04edebd2b18ef447eda3e
`tsdx.config.js` added in #183
JS support in #474, #486, #487, and patch fix of some edge case in #524

