### PR TITLE
fix/deps: dependabot YAML doesn't support anchors/aliases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,29 +1,35 @@
 version: 2
 
-# default configuration
-defaults: &defaults
-  package-ecosystem: npm
-  directory: '/'
-  schedule:
-    interval: weekly # don't spam daily
-  # only increase version when required, don't bump every patch or minor
-  versioning-strategy: increase-if-necessary
-  allow:
-    # only upgrade prod deps (not devDeps)
-    - dependency-name: '*'
-      dependency-type: production
-  commit-message:
-    prefix: 'deps:' # prefix commit with deps: for consistency
-
 updates:
   # configuration for /
-  - <<: *defaults
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly # don't spam daily
+    commit-message:
+      prefix: 'deps:' # prefix commit with deps: for consistency
+    # only increase version when required, don't bump every patch or minor
+    versioning-strategy: increase-if-necessary
+    allow:
+      # only upgrade prod deps (not devDeps)
+      - dependency-name: '*'
+        dependency-type: production
     # temporarily disable dep upgrade PRs for / as they're being updated
     open-pull-requests-limit: 0
 
   # configuration for /website
-  - <<: *defaults
+  - package-ecosystem: npm
     directory: /website
+    schedule:
+      interval: weekly # don't spam daily
+    commit-message:
+      prefix: 'deps:' # prefix commit with deps: for consistency
+    # only increase version when required, don't bump every patch or minor
+    versioning-strategy: increase-if-necessary
+    allow:
+      # only upgrade prod deps (not devDeps)
+      - dependency-name: '*'
+        dependency-type: production
     # /website is not a published package and doesn't really have an attack
     # surface area, should only be updated as needed, not as soon as deps change
     ignore:


### PR DESCRIPTION
## Description

- per bug report
- duplicate config because anchors/aliases aren't supported, which is a
  bit annoying

## Tags

Fixes #849 , follow-up to #846 