### PR TITLE
docs: add `patch-package` reference to Customization section

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Despite all the recent hype, setting up a new TypeScript (x React) library can b
   - [Babel](#babel)
   - [Jest](#jest)
   - [ESLint](#eslint)
+  - [`patch-package`](#patch-package)
 - [Inspiration](#inspiration)
   - [Comparison with Microbundle](#comparison-with-microbundle)
 - [API Reference](#api-reference)
@@ -386,6 +387,11 @@ You can add your own `jest.config.js` to the root of your project and TSDX will 
 ### ESLint
 
 You can add your own `.eslintrc.js` to the root of your project and TSDX will **deep merge** it with [its own ESLint config](./src/createEslintConfig.ts).
+
+### `patch-package`
+
+If you still need more customizations, we recommend using [`patch-package`](https://github.com/ds300/patch-package) so you don't need to fork.
+Keep in mind that these types of changes may be quite fragile against version updates.
 
 ## Inspiration
 


### PR DESCRIPTION
## Description

- for when you need to make some small changes to the internal code and
  forking is a bit too extreme of an option
  - hopefully patch-package means folks get their changes in faster
    without waiting for PRs and means folks don't have to use outdated
    forks etc

- it was first recommended by Shawn in issues then strongly recommended
  by Jared and I've recommended it a few times too for smaller changes
  - Quoting Jared: "Yes, to documenting patch-package as ultimate
    escape hatch"

## Tags

Referenced in:
- https://github.com/formium/tsdx/issues/110#issuecomment-518079299
- https://github.com/formium/tsdx/issues/389#issuecomment-568785862
- https://github.com/formium/tsdx/pull/436#issuecomment-578239297
- https://github.com/formium/tsdx/issues/509#issuecomment-586663005
- https://github.com/formium/tsdx/issues/656#issuecomment-612704650
- https://github.com/formium/tsdx/pull/669#issuecomment-612709831
- https://github.com/formium/tsdx/issues/744#issuecomment-643025596
- https://github.com/formium/tsdx/pull/811#discussion_r479410046
- https://github.com/formium/tsdx/issues/852#issuecomment-688420672