### PR TITLE
Add `--max-warnings` flag to `tsdx lint`

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,7 @@ Usage
 Options
   --fix               Fixes fixable errors and warnings
   --ignore-pattern    Ignore a pattern
+  --max-warnings      Exits with non-zero error code if number of warnings exceed this number  (default Infinity)
   --write-file        Write the config file locally
   --report-file       Write JSON report to file locally
   -h, --help          Displays this message
@@ -510,6 +511,7 @@ Examples
   $ tsdx lint src
   $ tsdx lint src --fix
   $ tsdx lint src test --ignore-pattern test/foo.ts
+  $ tsdx lint src test --max-warnings 10
   $ tsdx lint src --write-file
   $ tsdx lint src --report-file report.json
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -547,7 +547,8 @@ prog
   .example('lint src test --ignore-pattern test/foobar.ts')
   .option(
     '--max-warnings',
-    'Exits with non-zero error code if warnings exceed this number'
+    'Exits with non-zero error code if warnings exceed this number',
+    Infinity
   )
   .example('lint src test --max-warnings 10')
   .option('--write-file', 'Write the config file locally')
@@ -560,7 +561,7 @@ prog
       'ignore-pattern': string;
       'write-file': boolean;
       'report-file': string;
-      'max-warnings': number | undefined;
+      'max-warnings': number;
       _: string[];
     }) => {
       if (opts['_'].length === 0 && !opts['write-file']) {
@@ -603,10 +604,7 @@ prog
       if (report.errorCount) {
         process.exit(1);
       }
-      if (
-        opts['max-warnings'] !== undefined &&
-        report.warningCount > opts['max-warnings']
-      ) {
+      if (report.warningCount > opts['max-warnings']) {
         process.exit(1);
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -545,6 +545,11 @@ prog
   .example('lint src test --fix')
   .option('--ignore-pattern', 'Ignore a pattern')
   .example('lint src test --ignore-pattern test/foobar.ts')
+  .option(
+    '--max-warnings',
+    'Exits with non-zero error code if warnings exceed this number'
+  )
+  .example('lint src test --max-warnings 10')
   .option('--write-file', 'Write the config file locally')
   .example('lint --write-file')
   .option('--report-file', 'Write JSON report to file locally')

--- a/src/index.ts
+++ b/src/index.ts
@@ -555,6 +555,7 @@ prog
       'ignore-pattern': string;
       'write-file': boolean;
       'report-file': string;
+      'max-warnings': number | undefined;
       _: string[];
     }) => {
       if (opts['_'].length === 0 && !opts['write-file']) {
@@ -595,6 +596,12 @@ prog
         );
       }
       if (report.errorCount) {
+        process.exit(1);
+      }
+      if (
+        opts['max-warnings'] !== undefined &&
+        report.warningCount > opts['max-warnings']
+      ) {
         process.exit(1);
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -547,7 +547,7 @@ prog
   .example('lint src test --ignore-pattern test/foobar.ts')
   .option(
     '--max-warnings',
-    'Exits with non-zero error code if warnings exceed this number',
+    'Exits with non-zero error code if number of warnings exceed this number',
     Infinity
   )
   .example('lint src test --max-warnings 10')

--- a/test/e2e/fixtures/lint/file-with-lint-warnings.ts
+++ b/test/e2e/fixtures/lint/file-with-lint-warnings.ts
@@ -1,0 +1,4 @@
+const foo = () => {
+  const bar = 'baz';
+  const foobar = '';
+};

--- a/test/e2e/fixtures/lint/file-with-lint-warnings.ts
+++ b/test/e2e/fixtures/lint/file-with-lint-warnings.ts
@@ -1,4 +1,5 @@
-const foo = () => {
-  const bar = 'baz';
-  const foobar = '';
+// this file should have 3 "unused var" lint warnings
+const unusedVar1 = () => {
+  const unusedVar2 = 'baz';
+  const unusedVar3 = '';
 };

--- a/test/e2e/tsdx-lint.test.ts
+++ b/test/e2e/tsdx-lint.test.ts
@@ -30,6 +30,48 @@ describe('tsdx lint', () => {
     expect(output.stdout.includes('prettier/prettier')).toBe(true);
   });
 
+  it('should succeed linting a ts file with warnings when --max-warnings is not used', () => {
+    const testFile = `${lintDir}/file-with-lint-warnings.ts`;
+    const output = shell.exec(`node dist/index.js lint ${testFile}`);
+    expect(output.code).toBe(0);
+    expect(output.stdout.includes('@typescript-eslint/no-unused-vars')).toBe(
+      true
+    );
+  });
+
+  it('should succeed linting a ts file with fewer warnings than --max-warnings', () => {
+    const testFile = `${lintDir}/file-with-lint-warnings.ts`;
+    const output = shell.exec(
+      `node dist/index.js lint --max-warnings=4 ${testFile}`
+    );
+    expect(output.code).toBe(0);
+    expect(output.stdout.includes('@typescript-eslint/no-unused-vars')).toBe(
+      true
+    );
+  });
+
+  it('should succeed linting a ts file with same number of warnings as --max-warnings', () => {
+    const testFile = `${lintDir}/file-with-lint-warnings.ts`;
+    const output = shell.exec(
+      `node dist/index.js lint --max-warnings=3 ${testFile}`
+    );
+    expect(output.code).toBe(0);
+    expect(output.stdout.includes('@typescript-eslint/no-unused-vars')).toBe(
+      true
+    );
+  });
+
+  it('should fail to lint a ts file with more warnings than --max-warnings', () => {
+    const testFile = `${lintDir}/file-with-lint-warnings.ts`;
+    const output = shell.exec(
+      `node dist/index.js lint --max-warnings=2 ${testFile}`
+    );
+    expect(output.code).toBe(1);
+    expect(output.stdout.includes('@typescript-eslint/no-unused-vars')).toBe(
+      true
+    );
+  });
+
   it('should fail to lint a tsx file with errors', () => {
     const testFile = `${lintDir}/react-file-with-lint-errors.tsx`;
     const output = shell.exec(`node dist/index.js lint ${testFile}`);

--- a/test/e2e/tsdx-lint.test.ts
+++ b/test/e2e/tsdx-lint.test.ts
@@ -30,6 +30,19 @@ describe('tsdx lint', () => {
     expect(output.stdout.includes('prettier/prettier')).toBe(true);
   });
 
+  it('should fail to lint a tsx file with errors', () => {
+    const testFile = `${lintDir}/react-file-with-lint-errors.tsx`;
+    const output = shell.exec(`node dist/index.js lint ${testFile}`);
+    expect(output.code).toBe(1);
+    expect(output.stdout.includes('Parsing error:')).toBe(true);
+  });
+
+  it('should succeed linting a tsx file without errors', () => {
+    const testFile = `${lintDir}/react-file-without-lint-error.tsx`;
+    const output = shell.exec(`node dist/index.js lint ${testFile}`);
+    expect(output.code).toBe(0);
+  });
+
   it('should succeed linting a ts file with warnings when --max-warnings is not used', () => {
     const testFile = `${lintDir}/file-with-lint-warnings.ts`;
     const output = shell.exec(`node dist/index.js lint ${testFile}`);
@@ -70,19 +83,6 @@ describe('tsdx lint', () => {
     expect(output.stdout.includes('@typescript-eslint/no-unused-vars')).toBe(
       true
     );
-  });
-
-  it('should fail to lint a tsx file with errors', () => {
-    const testFile = `${lintDir}/react-file-with-lint-errors.tsx`;
-    const output = shell.exec(`node dist/index.js lint ${testFile}`);
-    expect(output.code).toBe(1);
-    expect(output.stdout.includes('Parsing error:')).toBe(true);
-  });
-
-  it('should succeed linting a tsx file without errors', () => {
-    const testFile = `${lintDir}/react-file-without-lint-error.tsx`;
-    const output = shell.exec(`node dist/index.js lint ${testFile}`);
-    expect(output.code).toBe(0);
   });
 
   it('should not lint', () => {

--- a/test/e2e/tsdx-lint.test.ts
+++ b/test/e2e/tsdx-lint.test.ts
@@ -42,7 +42,7 @@ describe('tsdx lint', () => {
   it('should succeed linting a ts file with fewer warnings than --max-warnings', () => {
     const testFile = `${lintDir}/file-with-lint-warnings.ts`;
     const output = shell.exec(
-      `node dist/index.js lint --max-warnings=4 ${testFile}`
+      `node dist/index.js lint ${testFile} --max-warnings 4`
     );
     expect(output.code).toBe(0);
     expect(output.stdout.includes('@typescript-eslint/no-unused-vars')).toBe(
@@ -53,7 +53,7 @@ describe('tsdx lint', () => {
   it('should succeed linting a ts file with same number of warnings as --max-warnings', () => {
     const testFile = `${lintDir}/file-with-lint-warnings.ts`;
     const output = shell.exec(
-      `node dist/index.js lint --max-warnings=3 ${testFile}`
+      `node dist/index.js lint ${testFile} --max-warnings 3`
     );
     expect(output.code).toBe(0);
     expect(output.stdout.includes('@typescript-eslint/no-unused-vars')).toBe(
@@ -64,7 +64,7 @@ describe('tsdx lint', () => {
   it('should fail to lint a ts file with more warnings than --max-warnings', () => {
     const testFile = `${lintDir}/file-with-lint-warnings.ts`;
     const output = shell.exec(
-      `node dist/index.js lint --max-warnings=2 ${testFile}`
+      `node dist/index.js lint ${testFile} --max-warnings 2`
     );
     expect(output.code).toBe(1);
     expect(output.stdout.includes('@typescript-eslint/no-unused-vars')).toBe(


### PR DESCRIPTION
Fixes #853 

Works in a similar way to the --max-warnings flag in ESLint.

If `tsdx lint` finds more than `--max-warnings` number of warnings, it exits with a non-zero code. Otherwise, it exits with 0.