### PR TITLE
multi-entry: temporarily change docs to singular "module"

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ Usage
   $ tsdx watch [options]
 
 Options
-  -i, --entry           Entry module(s)
+  -i, --entry           Entry module
   --target              Specify your target environment  (default web)
   --name                Specify name exposed in UMD builds
   --format              Specify module format(s)  (default cjs,esm)
@@ -457,7 +457,7 @@ Usage
   $ tsdx build [options]
 
 Options
-  -i, --entry           Entry module(s)
+  -i, --entry           Entry module
   --target              Specify your target environment  (default web)
   --name                Specify name exposed in UMD builds
   --format              Specify module format(s)  (default cjs,esm)

--- a/src/index.ts
+++ b/src/index.ts
@@ -363,7 +363,7 @@ prog
 prog
   .command('build')
   .describe('Build your project once and exit')
-  .option('--entry, -i', 'Entry module(s)')
+  .option('--entry, -i', 'Entry module')
   .example('build --entry src/foo.tsx')
   .option('--target', 'Specify your target environment', 'browser')
   .example('build --target node')

--- a/src/index.ts
+++ b/src/index.ts
@@ -254,7 +254,7 @@ prog
 prog
   .command('watch')
   .describe('Rebuilds on any change')
-  .option('--entry, -i', 'Entry module(s)')
+  .option('--entry, -i', 'Entry module')
   .example('watch --entry src/foo.tsx')
   .option('--target', 'Specify your target environment', 'browser')
   .example('watch --target node')


### PR DESCRIPTION
I spent ten minutes with adding globs and comma-separated paths before giving up going into the issues and searching/finding #175 / #367. 

Maybe delete the `(s)` until the issue is resolved to prevent other people from doing the same. :)