### PR TITLE
Add skipLibCheck, noEmit, consistentCasing, and lots of comments to template tsconfigs

### DIFF
--- a/templates/basic/tsconfig.json
+++ b/templates/basic/tsconfig.json
@@ -14,10 +14,11 @@
     // stricter type-checking for stronger correctness. Recommended by TS
     "strict": true,
     // linter checks for common issues
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
+    // noUnused* overlap with @typescript-eslint/no-unused-vars, can disable if duplicative
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     // use Node's module resolution algorithm, instead of the legacy TS one
     "moduleResolution": "node",
     // transpile JSX to React.createElement

--- a/templates/basic/tsconfig.json
+++ b/templates/basic/tsconfig.json
@@ -17,5 +17,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
   }
 }

--- a/templates/basic/tsconfig.json
+++ b/templates/basic/tsconfig.json
@@ -1,22 +1,34 @@
 {
+  // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
   "include": ["src", "types"],
   "compilerOptions": {
     "module": "esnext",
     "lib": ["dom", "esnext"],
     "importHelpers": true,
+    // output .d.ts declaration files for consumers
     "declaration": true,
+    // output .js.map sourcemap files for consumers
     "sourceMap": true,
+    // match output dir to input dir. e.g. dist/index instead of dist/src/index
     "rootDir": "./src",
+    // stricter type-checking for stronger correctness. Recommended by TS
     "strict": true,
+    // linter checks for common issues
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
+    // use Node's module resolution algorithm, instead of the legacy TS one
     "moduleResolution": "node",
+    // transpile JSX to React.createElement
     "jsx": "react",
+    // interop between ESM and CJS modules. Recommended by TS
     "esModuleInterop": true,
+    // significant perf increase by skipping checking .d.ts files, particularly those in node_modules. Recommended by TS
     "skipLibCheck": true,
+    // error out if import and file system have a casing mismatch. Recommended by TS
     "forceConsistentCasingInFileNames": true,
+    // `tsdx build` ignores this option, but it is commonly used when type-checking separately with `tsc`
     "noEmit": true,
   }
 }

--- a/templates/basic/tsconfig.json
+++ b/templates/basic/tsconfig.json
@@ -14,6 +14,8 @@
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
     "jsx": "react",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
   }
 }

--- a/templates/react-with-storybook/tsconfig.json
+++ b/templates/react-with-storybook/tsconfig.json
@@ -14,10 +14,11 @@
     // stricter type-checking for stronger correctness. Recommended by TS
     "strict": true,
     // linter checks for common issues
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
+    // noUnused* overlap with @typescript-eslint/no-unused-vars, can disable if duplicative
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     // use Node's module resolution algorithm, instead of the legacy TS one
     "moduleResolution": "node",
     // transpile JSX to React.createElement

--- a/templates/react-with-storybook/tsconfig.json
+++ b/templates/react-with-storybook/tsconfig.json
@@ -17,5 +17,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
   }
 }

--- a/templates/react-with-storybook/tsconfig.json
+++ b/templates/react-with-storybook/tsconfig.json
@@ -1,22 +1,34 @@
 {
+  // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
   "include": ["src", "types"],
   "compilerOptions": {
     "module": "esnext",
     "lib": ["dom", "esnext"],
     "importHelpers": true,
+    // output .d.ts declaration files for consumers
     "declaration": true,
+    // output .js.map sourcemap files for consumers
     "sourceMap": true,
+    // match output dir to input dir. e.g. dist/index instead of dist/src/index
     "rootDir": "./src",
+    // stricter type-checking for stronger correctness. Recommended by TS
     "strict": true,
+    // linter checks for common issues
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
+    // use Node's module resolution algorithm, instead of the legacy TS one
     "moduleResolution": "node",
+    // transpile JSX to React.createElement
     "jsx": "react",
+    // interop between ESM and CJS modules. Recommended by TS
     "esModuleInterop": true,
+    // significant perf increase by skipping checking .d.ts files, particularly those in node_modules. Recommended by TS
     "skipLibCheck": true,
+    // error out if import and file system have a casing mismatch. Recommended by TS
     "forceConsistentCasingInFileNames": true,
+    // `tsdx build` ignores this option, but it is commonly used when type-checking separately with `tsc`
     "noEmit": true,
   }
 }

--- a/templates/react-with-storybook/tsconfig.json
+++ b/templates/react-with-storybook/tsconfig.json
@@ -14,6 +14,8 @@
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
     "jsx": "react",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
   }
 }

--- a/templates/react/tsconfig.json
+++ b/templates/react/tsconfig.json
@@ -14,10 +14,11 @@
     // stricter type-checking for stronger correctness. Recommended by TS
     "strict": true,
     // linter checks for common issues
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
+    // noUnused* overlap with @typescript-eslint/no-unused-vars, can disable if duplicative
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     // use Node's module resolution algorithm, instead of the legacy TS one
     "moduleResolution": "node",
     // transpile JSX to React.createElement

--- a/templates/react/tsconfig.json
+++ b/templates/react/tsconfig.json
@@ -17,5 +17,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
   }
 }

--- a/templates/react/tsconfig.json
+++ b/templates/react/tsconfig.json
@@ -1,22 +1,34 @@
 {
+  // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
   "include": ["src", "types"],
   "compilerOptions": {
     "module": "esnext",
     "lib": ["dom", "esnext"],
     "importHelpers": true,
+    // output .d.ts declaration files for consumers
     "declaration": true,
+    // output .js.map sourcemap files for consumers
     "sourceMap": true,
+    // match output dir to input dir. e.g. dist/index instead of dist/src/index
     "rootDir": "./src",
+    // stricter type-checking for stronger correctness. Recommended by TS
     "strict": true,
+    // linter checks for common issues
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
+    // use Node's module resolution algorithm, instead of the legacy TS one
     "moduleResolution": "node",
+    // transpile JSX to React.createElement
     "jsx": "react",
+    // interop between ESM and CJS modules. Recommended by TS
     "esModuleInterop": true,
+    // significant perf increase by skipping checking .d.ts files, particularly those in node_modules. Recommended by TS
     "skipLibCheck": true,
+    // error out if import and file system have a casing mismatch. Recommended by TS
     "forceConsistentCasingInFileNames": true,
+    // `tsdx build` ignores this option, but it is commonly used when type-checking separately with `tsc`
     "noEmit": true,
   }
 }

--- a/templates/react/tsconfig.json
+++ b/templates/react/tsconfig.json
@@ -14,6 +14,8 @@
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
     "jsx": "react",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
   }
 }

--- a/test/e2e/fixtures/build-default/tsconfig.json
+++ b/test/e2e/fixtures/build-default/tsconfig.json
@@ -12,7 +12,9 @@
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
     "jsx": "react",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src", "types"]
 }

--- a/test/e2e/fixtures/build-default/tsconfig.json
+++ b/test/e2e/fixtures/build-default/tsconfig.json
@@ -14,7 +14,8 @@
     "jsx": "react",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
   },
   "include": ["src", "types"]
 }

--- a/test/e2e/fixtures/build-invalid/tsconfig.json
+++ b/test/e2e/fixtures/build-invalid/tsconfig.json
@@ -12,7 +12,9 @@
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
     "jsx": "react",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src", "types"]
 }

--- a/test/e2e/fixtures/build-invalid/tsconfig.json
+++ b/test/e2e/fixtures/build-invalid/tsconfig.json
@@ -14,7 +14,8 @@
     "jsx": "react",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
   },
   "include": ["src", "types"]
 }

--- a/test/e2e/fixtures/build-withTsconfig/tsconfig.base.json
+++ b/test/e2e/fixtures/build-withTsconfig/tsconfig.base.json
@@ -16,7 +16,8 @@
     "jsx": "react",
     "esModuleInterop": false,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
   },
   "include": ["src", "types"], // test parsing of trailing comma & comment
 }

--- a/test/e2e/fixtures/build-withTsconfig/tsconfig.base.json
+++ b/test/e2e/fixtures/build-withTsconfig/tsconfig.base.json
@@ -14,7 +14,9 @@
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
     "jsx": "react",
-    "esModuleInterop": false
+    "esModuleInterop": false,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src", "types"], // test parsing of trailing comma & comment
 }

--- a/test/integration/fixtures/build-options/tsconfig.json
+++ b/test/integration/fixtures/build-options/tsconfig.json
@@ -12,7 +12,9 @@
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
     "jsx": "react",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src", "types"],
 }

--- a/test/integration/fixtures/build-options/tsconfig.json
+++ b/test/integration/fixtures/build-options/tsconfig.json
@@ -14,7 +14,8 @@
     "jsx": "react",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
   },
   "include": ["src", "types"],
 }

--- a/test/integration/fixtures/build-withBabel/tsconfig.json
+++ b/test/integration/fixtures/build-withBabel/tsconfig.json
@@ -12,7 +12,9 @@
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
     "jsx": "react",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src", "types"],
 }

--- a/test/integration/fixtures/build-withBabel/tsconfig.json
+++ b/test/integration/fixtures/build-withBabel/tsconfig.json
@@ -14,7 +14,8 @@
     "jsx": "react",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": false
   },
   "include": ["src", "types"],
 }

--- a/test/integration/fixtures/build-withConfig/tsconfig.json
+++ b/test/integration/fixtures/build-withConfig/tsconfig.json
@@ -12,7 +12,9 @@
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
     "jsx": "react",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src", "types"],
 }

--- a/test/integration/fixtures/build-withConfig/tsconfig.json
+++ b/test/integration/fixtures/build-withConfig/tsconfig.json
@@ -14,7 +14,8 @@
     "jsx": "react",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
   },
   "include": ["src", "types"],
 }


### PR DESCRIPTION
## Description

### Commits 

#### feat: add skipLibCheck and forceConsistentCasingInFileNames
- as defaults to the templates' tsconfigs
  - these are now recommended by TS to be set to true, which can be
    seen in the TSConfig Reference and @tsconfig/recommended
    - c.f. https://www.typescriptlang.org/tsconfig and
      https://www.npmjs.com/package/@tsconfig/recommended
  - also add to all fixtures
    - yea some centralization/extends or dogfooding create would help
      reduce all this duplication

- skipLibCheck is a big perf gain, though it seems to only affect
  `tsc --noEmit` usage and rollup-plugin-typescript2 seems to ignore it
  - I have an existing issue open on the matter
- forceConsistentCasingInFileNames is a no-brainer to help avoid a bug
  that is easy to make and hard to debug

- also add a trailing comma for ease of use and better diffing
  - not to fixtures though, because there is a test for this

#### feat: add noEmit to templates' tsconfigs
- for ease of use when using `tsc` for type-checking, which a lot of
  users already do
  - it doesn't fully type-check everything though, since we'd need to
    split off a tsconfig.build.json in order to let builds only run on
    `src` while type-checking would run on all files
    - but people already using `tsc --noEmit`, so might as well start
      supporting this as it's not uncommon

- also add to all fixtures
  - yea some centralization/extends or dogfooding create would help
    reduce all this duplication

#### docs: add comments for nearly all tsconfig options in use
- since we can use comments in tsconfig.json, add them to give simple,
  one-liner explanations as to what each setting does
- also add a link to the TSConfig Reference for further details
- and specify which options are recommended as true by TS but not on by
  default for backwards compat or other reasons

- a few leftover that I still need to think about

#### docs: add comment that noUnused* overlaps with an ESLint rule
- the checks overlap with the @typescript-eslint/no-unused-vars rule
- per user issue, this can result in duplicative errors inside an IDE,
  so explicitly call this out in a comment for `tsdx lint` / ESLint
  users in case they'd like to disable this and leave only one on

- change the ordering of linter checks in the templates as well to make
  the comments easier to read/understand

## Tags

- Fixes #529 as requested, since, per https://github.com/formium/tsdx/issues/529#issuecomment-679746098 these are now the defaults upstream as well
- Fixes #619 , the second part about duplication with ESLint, by adding a comment as suggested in https://github.com/formium/tsdx/issues/619#issuecomment-600227877

- Comments and trailing comma are a result of #483 / #489 , since I didn't realize this was possible before
  - I've written in several issues in a few places (can't remember them all now) that I think comments would be useful, so have finally gotten to it for _most_ of the `tsconfig` (but not quite all, and not including some forced or commented out options, i.e. https://github.com/formium/tsdx/issues/760#issuecomment-692979270)
  - `tsc --init` has comments too as existing precedent

## Review Notes

Key thing to check would be that all 3 templates and all 6 fixtures are similarly updated