### PR TITLE
fix: remove redundant CI env from workflow steps

### DIFF
--- a/templates/basic/.github/workflows/main.yml
+++ b/templates/basic/.github/workflows/main.yml
@@ -23,20 +23,12 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-        env:
-          CI: true
 
       - name: Lint
         run: yarn lint
-        env:
-          CI: true
 
       - name: Test
         run: yarn test --ci --coverage --maxWorkers=2
-        env:
-          CI: true
 
       - name: Build
         run: yarn build
-        env:
-          CI: true

--- a/templates/react-with-storybook/.github/workflows/main.yml
+++ b/templates/react-with-storybook/.github/workflows/main.yml
@@ -23,20 +23,12 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-        env:
-          CI: true
 
       - name: Lint
         run: yarn lint
-        env:
-          CI: true
 
       - name: Test
         run: yarn test --ci --coverage --maxWorkers=2
-        env:
-          CI: true
 
       - name: Build
         run: yarn build
-        env:
-          CI: true

--- a/templates/react/.github/workflows/main.yml
+++ b/templates/react/.github/workflows/main.yml
@@ -23,20 +23,12 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-        env:
-          CI: true
 
       - name: Lint
         run: yarn lint
-        env:
-          CI: true
 
       - name: Test
         run: yarn test --ci --coverage --maxWorkers=2
-        env:
-          CI: true
 
       - name: Build
         run: yarn build
-        env:
-          CI: true


### PR DESCRIPTION
Thanks for adding GH actions to the templates,
it's awesome and greatly reduces overhead of adding CI on new packages.
I always end up needing to read the damm docs again for every project 🙈 

**nitpick** fix on this PR:
`CI=true` is already declared at runner level.

docs: [default-environment-variables](https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables)