### PR TITLE
ci: update matrix to use Node 14 instead of Node 13

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -31,7 +31,7 @@ jobs:
 
     strategy:
       matrix:
-        node: ['10.x', '12.x', '13.x']
+        node: ['10.x', '12.x', '14.x']
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     name: Test on node ${{ matrix.node }} and ${{ matrix.os }}


### PR DESCRIPTION
## Description

- Node 13.x was EoL at the beginning of June per
  https://github.com/nodejs/Release
  - similarly we just recently updated @types/node to v14

## Tags

`@types/node` was updated to v14 in #879 