### PR TITLE
docs: remove reference to Node 10+ req for create

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,6 @@ cd mylib
 yarn start
 ```
 
-_Requires Node `>= 10`._
-
-
 That's it. You don't need to worry about setting up TypeScript or Rollup or Jest or other plumbing. Just start editing `src/index.ts` and go!
 
 Below is a list of commands you will probably find useful:


### PR DESCRIPTION
## Description

- TSDX itself has a Node 10 requirement on package.json#engines now,
  so this is fairly explicit already and not limited to `tsdx create`
  anymore either

- Node 8 was also EoL quite a while ago at the end of last year, so this
  isn't quite as important of a note anymore

## Tags

Follow-up to #678 where I think I decided to leave it in for some reason, but I didn't comment why so I don't remember.

Removes a doc entry from #433