### PR TITLE
Improve template CI: add matrix testing, use `bahmutov/npm-install`

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,8 +11,9 @@ jobs:
     name: Lint & Deduplicate deps on node 10.x and ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-      - name: Use Node.js 10.x
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Use Node 10.x
         uses: actions/setup-node@v1
         with:
           node-version: 10.x
@@ -27,18 +28,18 @@ jobs:
         run: yarn deduplicate:check
 
   test:
-    runs-on: ${{ matrix.os }}
+    name: Test on Node ${{ matrix.node }} and ${{ matrix.os }}
 
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         node: ['10.x', '12.x', '13.x']
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
-    name: Test on node ${{ matrix.node }} and ${{ matrix.os }}
-
     steps:
-      - uses: actions/checkout@v1
-      - name: Use Node.js ${{ matrix.node }}
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}

--- a/templates/basic/.github/workflows/main.yml
+++ b/templates/basic/.github/workflows/main.yml
@@ -13,16 +13,8 @@ jobs:
         with:
           node-version: 12.x
 
-      - name: Use cached node_modules
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: nodeModules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            nodeModules-
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
+      - name: Install deps and build (with cache)
+        uses: bahmutov/npm-install@v1
 
       - name: Lint
         run: yarn lint

--- a/templates/basic/.github/workflows/main.yml
+++ b/templates/basic/.github/workflows/main.yml
@@ -2,16 +2,22 @@ name: CI
 on: [push]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: Build, lint, and test on Node ${{ matrix.node }} and ${{ matrix.os }}
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node: ['10.x', '12.x', '14.x']
+        os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-      - name: Begin CI...
+      - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Use Node 12
+      - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: ${{ matrix.node }}
 
       - name: Install deps and build (with cache)
         uses: bahmutov/npm-install@v1

--- a/templates/basic/README.md
+++ b/templates/basic/README.md
@@ -63,7 +63,7 @@ TSDX uses [Rollup](https://rollupjs.org) as a bundler and generates multiple rol
 
 Two actions are added by default:
 
-- `main` which installs deps w/ cache, lints, tests, and builds on all pushes
+- `main` which installs deps w/ cache, lints, tests, and builds on all pushes against a Node and OS matrix
 - `size` which comments cost comparison of your library on every pull request using [`size-limit`](https://github.com/ai/size-limit)
 
 ## Optimizations

--- a/templates/react-with-storybook/.github/workflows/main.yml
+++ b/templates/react-with-storybook/.github/workflows/main.yml
@@ -13,16 +13,8 @@ jobs:
         with:
           node-version: 12.x
 
-      - name: Use cached node_modules
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: nodeModules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            nodeModules-
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
+      - name: Install deps and build (with cache)
+        uses: bahmutov/npm-install@v1
 
       - name: Lint
         run: yarn lint

--- a/templates/react-with-storybook/.github/workflows/main.yml
+++ b/templates/react-with-storybook/.github/workflows/main.yml
@@ -2,16 +2,22 @@ name: CI
 on: [push]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: Build, lint, and test on Node ${{ matrix.node }} and ${{ matrix.os }}
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node: ['10.x', '12.x', '14.x']
+        os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-      - name: Begin CI...
+      - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Use Node 12
+      - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: ${{ matrix.node }}
 
       - name: Install deps and build (with cache)
         uses: bahmutov/npm-install@v1

--- a/templates/react-with-storybook/README.md
+++ b/templates/react-with-storybook/README.md
@@ -103,7 +103,7 @@ TSDX uses [Rollup](https://rollupjs.org) as a bundler and generates multiple rol
 
 Two actions are added by default:
 
-- `main` which runs installs deps w/ cache, lints, tests, and builds on all pushes
+- `main` which installs deps w/ cache, lints, tests, and builds on all pushes against a Node and OS matrix
 - `size` which comments cost comparison of your library on every pull request using [size-limit](https://github.com/ai/size-limit)
 
 ## Optimizations

--- a/templates/react/.github/workflows/main.yml
+++ b/templates/react/.github/workflows/main.yml
@@ -13,16 +13,8 @@ jobs:
         with:
           node-version: 12.x
 
-      - name: Use cached node_modules
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: nodeModules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            nodeModules-
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
+      - name: Install deps and build (with cache)
+        uses: bahmutov/npm-install@v1
 
       - name: Lint
         run: yarn lint

--- a/templates/react/.github/workflows/main.yml
+++ b/templates/react/.github/workflows/main.yml
@@ -2,16 +2,22 @@ name: CI
 on: [push]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: Build, lint, and test on Node ${{ matrix.node }} and ${{ matrix.os }}
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node: ['10.x', '12.x', '14.x']
+        os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-      - name: Begin CI...
+      - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Use Node 12
+      - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: ${{ matrix.node }}
 
       - name: Install deps and build (with cache)
         uses: bahmutov/npm-install@v1

--- a/templates/react/README.md
+++ b/templates/react/README.md
@@ -82,8 +82,8 @@ TSDX uses [Rollup](https://rollupjs.org) as a bundler and generates multiple rol
 
 Two actions are added by default:
 
-- `main` which runs installs deps w/ cache, lints, tests, and builds on all pushes
-- `size` which comments cost comparison of your library on every pull request using
+- `main` which installs deps w/ cache, lints, tests, and builds on all pushes against a Node and OS matrix
+- `size` which comments cost comparison of your library on every pull request using [`size-limit`](https://github.com/ai/size-limit)
 
 ## Optimizations
 


### PR DESCRIPTION
## Description

### Commits

#### fix: use @bahmutov/npm-install in templates' CI
- have been using this internally for about 6 months and I've personally
  contributed [bugfixes](https://github.com/bahmutov/npm-install/pull/37) and [optimizations](https://github.com/bahmutov/npm-install/pull/43) to it, so should be good to
  use by general users too
  - it's a good bit less configuration, which is particularly better for
    beginners, but even for advanced users, it means that improvements
    are shared out to all users
  - I also [recommended it in an actions/cache issue](https://github.com/actions/cache/issues/94#issuecomment-674398895) about needing too
    much config already too, which I wouldn't have done if I weren't
    confident in its usage now

- this properly caches node_modules by using ~/.npm or Yarn's cache dir
  as recommended, instead of `node_modules` itself, which is not
  - c.f. https://github.com/actions/cache/blob/main/examples.md#node---npm

- it's also not susceptible to [the `**/yarn.lock` issue](https://github.com/formium/tsdx/issues/799) that was
  reported because it caches the _one_ lockfile directly instead of
  potentially multiple lockfiles

#### feat: add test matrix to all templates' CI …
- have been using this internally for [about a year now](https://github.com/formium/tsdx/pull/203), so should be
  good to use by general users too
  - the [original proposal](https://github.com/formium/tsdx/issues/438) to add Actions to all templates also suggested
    adding matrix testing, but that didn't make it into the original PR

- support Node 10, 12, and 14, as well as ubuntu, macOS, and windows
  latest
  - add a note in the docs mentioning the test matrix
    - also fix [one doc's missing `size-limit` link](https://github.com/formium/tsdx/pull/705/files#diff-a0ba6de9261deb686f2bc4eb75221237R86)
      - not sure how that got missed

- add clear names to all jobs and steps as well
  - change some to include the matrix variant that is currently running
  - "Begin CI..." was not really clear, use "Checkout repo" instead

#### ci: make internal job names more consistent w/ templates' …
- Adding a matrix and `bahmutov/npm-install` brought the templates
  closer to internal, now do the inverse

- Add "Checkout repo" name for checkout Action
  - previously had no name internally
- Reorder config options for matrix to match templates
- Use "Node" consistently, not "node" or "Node.js"

- Also upgrade to actions/checkout@v2 since the templates have had that
  since their inception

## Tags

### References
- Actions were originally added in #457. Proposal that mentions matrix testing is #438
- Internal matrix testing was added in #203
- Internal use of `bahmutov/npm-install` was added in #625 
  - Changing templates' caching to use this was also mentioned in https://github.com/formium/tsdx/pull/750#issuecomment-649694090
- Upstream refs to `bahmutov/npm-install`: https://github.com/bahmutov/npm-install/pull/37,  https://github.com/bahmutov/npm-install/pull/43, https://github.com/actions/cache/issues/94#issuecomment-674398895

### Fixes

This fixes #799 because `bahmutov/npm-install` isn't susceptible to that issue. Would still like to hear from upstream why they used `**/yarn.lock` but https://github.com/actions/cache/issues/400 hasn't gotten a response in over a month 😕 
- As a result, this also closes #800, which was made to fix #799

