### PR TITLE
fix: don't replace lodash/fp imports with lodash-es/fp

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
   "devDependencies": {
     "@types/eslint": "^6.1.2",
     "@types/fs-extra": "^9.0.1",
+    "@types/lodash": "^4.14.161",
     "@types/node": "^14.11.1",
     "@types/react": "^16.9.11",
     "@types/rollup-plugin-json": "^3.0.2",

--- a/src/babelPluginTsdx.ts
+++ b/src/babelPluginTsdx.ts
@@ -10,7 +10,8 @@ export const isTruthy = (obj?: any) => {
   return obj.constructor !== Object || Object.keys(obj).length > 0;
 };
 
-const replacements = [{ original: 'lodash', replacement: 'lodash-es' }];
+// replace lodash with lodash-es, but not lodash/fp
+const replacements = [{ original: 'lodash(?!/fp)', replacement: 'lodash-es' }];
 
 export const mergeConfigItems = (type: any, ...configItemsToMerge: any[]) => {
   const mergedItems: any[] = [];

--- a/test/e2e/fixtures/build-default/src/index.ts
+++ b/test/e2e/fixtures/build-default/src/index.ts
@@ -6,6 +6,9 @@ import './syntax/jsx-import/JSX-import-JSX';
 import './syntax/async';
 export { testGenerator } from './syntax/generator';
 
+export { kebabCase } from 'lodash';
+export { merge, mergeAll } from 'lodash/fp';
+
 export { foo } from './foo';
 
 export const sum = (a: number, b: number) => {

--- a/test/e2e/tsdx-build-default.test.ts
+++ b/test/e2e/tsdx-build-default.test.ts
@@ -67,6 +67,14 @@ describe('tsdx build :: zero-config defaults', () => {
     expect(matched).toBeFalsy();
   });
 
+  it("shouldn't replace lodash/fp", () => {
+    const output = execWithCache('node ../dist/index.js build');
+    expect(output.code).toBe(0);
+
+    const matched = grep(/lodash\/fp/, ['dist/build-default.*.js']);
+    expect(matched).toBeTruthy();
+  });
+
   it('should clean the dist directory before rebuilding', () => {
     let output = execWithCache('node ../dist/index.js build');
     expect(output.code).toBe(0);

--- a/test/e2e/tsdx-build-default.test.ts
+++ b/test/e2e/tsdx-build-default.test.ts
@@ -67,6 +67,22 @@ describe('tsdx build :: zero-config defaults', () => {
     expect(matched).toBeFalsy();
   });
 
+  it('should use lodash for the CJS build', () => {
+    const output = execWithCache('node ../dist/index.js build');
+    expect(output.code).toBe(0);
+
+    const matched = grep(/lodash/, ['dist/build-default.cjs.*.js']);
+    expect(matched).toBeTruthy();
+  });
+
+  it('should use lodash-es for the ESM build', () => {
+    const output = execWithCache('node ../dist/index.js build');
+    expect(output.code).toBe(0);
+
+    const matched = grep(/lodash-es/, ['dist/build-default.esm.js']);
+    expect(matched).toBeTruthy();
+  });
+
   it("shouldn't replace lodash/fp", () => {
     const output = execWithCache('node ../dist/index.js build');
     expect(output.code).toBe(0);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1314,6 +1314,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/lodash@^4.14.161":
+  version "4.14.161"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.161.tgz#a21ca0777dabc6e4f44f3d07f37b765f54188b18"
+  integrity sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==
+
 "@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"


### PR DESCRIPTION
When importing modules from `lodash/fp` we get breaking imports since `babel-plugin-transform-rename-import` renames all `lodash` imports to `lodash-es` for the esm build.

e.g `import mergeAll from 'lodash/fp/mergeAll';` ends up being imported like `import mergeAll from 'lodash-es/fp/mergeAll'` and we get an error since `lodash-es/fp` doesn't exist.

With this fix we rename all `lodash-es/fp` imports to `lodash/fp` and we get the correct imports in the final esm build.