### PR TITLE
deps: ignore dependabot for peer dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,20 @@ updates:
       # only upgrade prod deps (not devDeps)
       - dependency-name: '*'
         dependency-type: production
+    ignore:
+      # ignore eslint-config-react-app's peerDeps
+      - dependency-name: '@typescript-eslint/eslint-plugin'
+      - dependency-name: '@typescript-eslint/parser'
+      - dependency-name: 'babel-eslint'
+      - dependency-name: 'eslint-plugin-flowtype'
+      - dependency-name: 'eslint-plugin-import'
+      - dependency-name: 'eslint-plugin-jsx-a11y'
+      - dependency-name: 'eslint-plugin-react'
+      - dependency-name: 'eslint-plugin-react-hooks'
+      # ignore Jest's "peers" that should be upgraded simultaneously with Jest
+      - dependency-name: '@types/jest'
+      - dependency-name: 'jest-watch-typeahead'
+      - dependency-name: 'ts-jest'
     # temporarily disable dep upgrade PRs for / as they're being updated
     open-pull-requests-limit: 0
 


### PR DESCRIPTION
## Description

- several of the dependencies in the tree are only there because they
  are peerDeps, and not because we directly depend on them
  - they should only be upgraded in tandem with the dep(s) they are
    peers of and pretty much never in isolation

- Greenkeeper made several PRs for peers which previously caused an
  erroneous/buggy update of `@types/jest` to 25 many months before Jest
  was upgraded to 25
  - and honestly those Greenkeeper PRs for peers had confused me a
    good deal too

## Tags

- #462 was a previous erroneous PR due to Greenkeeper updating peers, which was reverted in #470 
- This directly addresses some of my previous confusion from `eslint-config-react-app` peers in https://github.com/formium/tsdx/pull/640#issuecomment-702894150 / https://github.com/formium/tsdx/pull/642#issuecomment-702892887 / https://github.com/formium/tsdx/pull/728#issuecomment-702892139 / https://github.com/formium/tsdx/pull/729#issuecomment-702892420 / https://github.com/formium/tsdx/pull/890#issuecomment-700292943 
- #709 updated `jest-watch-typeahead` to a version for Jest 26 before we even upgraded to Jest 25

Let's close some of the confusing Greenkeeper peer update PRs now that this has been configured:
- Closes #640
- Closes #642
- Closes #728
- Closes #729
- Closes #709

## Review Notes

I straight copy+pasted the `eslint-config-react-app` peerDeps from [its `package.json`](https://github.com/facebook/create-react-app/blob/7641a3c1c6d02cd707ac11e7b8b8907acf3df7c0/packages/eslint-config-react-app/package.json#L17), so they're alphabetized the same way and shouldn't have any spelling mistakes.