### PR TITLE
Refactor/Improve some typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ module.exports = {
 The `options` object contains the following:
 
 ```tsx
-export interface TsdxOptions {
+export interface TSDXOptions {
   // path to file
   input: string;
   // Name of package
@@ -375,7 +375,7 @@ module.exports = {
 
 ### Babel
 
-You can add your own `.babelrc` to the root of your project and TSDX will **merge** it with [its own Babel transforms](./src/babelPluginTsdx.ts) (which are mostly for optimization), putting any new presets and plugins at the end of its list.
+You can add your own `.babelrc` to the root of your project and TSDX will **merge** it with [its own Babel transforms](./src/babelPluginTSDX.ts) (which are mostly for optimization), putting any new presets and plugins at the end of its list.
 
 ### Jest
 

--- a/package.json
+++ b/package.json
@@ -99,9 +99,12 @@
     "typescript": "^3.7.3"
   },
   "devDependencies": {
+    "@types/babel__core": "^7.1.10",
+    "@types/babel__traverse": "^7.0.15",
     "@types/eslint": "^6.1.2",
     "@types/fs-extra": "^9.0.1",
     "@types/lodash": "^4.14.161",
+    "@types/lodash.merge": "^4.6.6",
     "@types/node": "^14.11.1",
     "@types/react": "^16.9.11",
     "@types/rollup-plugin-json": "^3.0.2",

--- a/src/babelPluginTSDX.ts
+++ b/src/babelPluginTSDX.ts
@@ -64,7 +64,7 @@ type IBabelPluginTSDX = (
 // temp workaround so prettier doesn't reformat 100 lines for indentation
 const shortBabelPlugin = createBabelInputPluginFactory;
 
-export const babelPluginTsdx: IBabelPluginTSDX = shortBabelPlugin(() => ({
+export const babelPluginTSDX: IBabelPluginTSDX = shortBabelPlugin(() => ({
   // Passed the plugin options.
   options({ custom: customOptions, ...pluginOptions }: any) {
     return {

--- a/src/babelPluginTsdx.ts
+++ b/src/babelPluginTsdx.ts
@@ -1,5 +1,9 @@
 import { createConfigItem } from '@babel/core';
-import { createBabelInputPluginFactory } from '@rollup/plugin-babel';
+import {
+  createBabelInputPluginFactory,
+  RollupBabelInputPluginOptions,
+} from '@rollup/plugin-babel';
+import { Plugin } from 'rollup';
 import merge from 'lodash.merge';
 
 export const isTruthy = (obj?: any) => {
@@ -48,7 +52,19 @@ export const createConfigItems = (type: any, items: any[]) => {
   });
 };
 
-export const babelPluginTsdx = createBabelInputPluginFactory(() => ({
+// augment with `custom` since it's added in `options` below
+type IBabelPluginTSDX = (
+  options: RollupBabelInputPluginOptions & {
+    custom: any;
+    // not sure if @types/babel__core is incorrect or this is actually ignored
+    passPerPreset: boolean;
+  }
+) => Plugin;
+
+// temp workaround so prettier doesn't reformat 100 lines for indentation
+const shortBabelPlugin = createBabelInputPluginFactory;
+
+export const babelPluginTsdx: IBabelPluginTSDX = shortBabelPlugin(() => ({
   // Passed the plugin options.
   options({ custom: customOptions, ...pluginOptions }: any) {
     return {

--- a/src/createBuildConfigs.ts
+++ b/src/createBuildConfigs.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs-extra';
 import { concatAllArray } from 'jpjs';
 
 import { paths } from './constants';
-import { TSDXOptions, NormalizedOpts } from './types';
+import { TSDXOptions, AtLeastOneTSDXOptions, NormalizedOpts } from './types';
 
 import { createRollupConfig } from './createRollupConfig';
 
@@ -46,7 +46,7 @@ export async function createBuildConfigs(
 function createAllFormats(
   opts: NormalizedOpts,
   input: string
-): [TSDXOptions, ...TSDXOptions[]] {
+): AtLeastOneTSDXOptions {
   return [
     opts.format.includes('cjs') && {
       ...opts,
@@ -85,5 +85,5 @@ function createAllFormats(
       env: 'production',
       input,
     },
-  ].filter(Boolean) as [TSDXOptions, ...TSDXOptions[]];
+  ].filter(Boolean) as AtLeastOneTSDXOptions;
 }

--- a/src/createBuildConfigs.ts
+++ b/src/createBuildConfigs.ts
@@ -1,9 +1,9 @@
-import { RollupOptions } from 'rollup';
 import * as fs from 'fs-extra';
 import { concatAllArray } from 'jpjs';
 
 import { paths } from './constants';
 import {
+  TSDXConfig,
   TSDXOptions,
   AtLeastOneTSDXOptions,
   NormalizedOpts,
@@ -13,8 +13,8 @@ import {
 import { createRollupConfig } from './createRollupConfig';
 
 // check for custom tsdx.config.js
-let tsdxConfig = {
-  rollup(config: RollupOptions, _options: TSDXOptions): RollupOptions {
+let tsdxConfig: TSDXConfig = {
+  rollup(config, _options) {
     return config;
   },
 };

--- a/src/createBuildConfigs.ts
+++ b/src/createBuildConfigs.ts
@@ -3,13 +3,13 @@ import * as fs from 'fs-extra';
 import { concatAllArray } from 'jpjs';
 
 import { paths } from './constants';
-import { TsdxOptions, NormalizedOpts } from './types';
+import { TSDXOptions, NormalizedOpts } from './types';
 
 import { createRollupConfig } from './createRollupConfig';
 
 // check for custom tsdx.config.js
 let tsdxConfig = {
-  rollup(config: RollupOptions, _options: TsdxOptions): RollupOptions {
+  rollup(config: RollupOptions, _options: TSDXOptions): RollupOptions {
     return config;
   },
 };
@@ -24,7 +24,7 @@ export async function createBuildConfigs(
   const allInputs = concatAllArray(
     opts.input.map((input: string) =>
       createAllFormats(opts, input).map(
-        (options: TsdxOptions, index: number) => ({
+        (options: TSDXOptions, index: number) => ({
           ...options,
           // We want to know if this is the first run for each entryfile
           // for certain plugins (e.g. css)
@@ -35,7 +35,7 @@ export async function createBuildConfigs(
   );
 
   return await Promise.all(
-    allInputs.map(async (options: TsdxOptions, index: number) => {
+    allInputs.map(async (options: TSDXOptions, index: number) => {
       // pass the full rollup config to tsdx.config.js override
       const config = await createRollupConfig(options, index);
       return tsdxConfig.rollup(config, options);
@@ -46,7 +46,7 @@ export async function createBuildConfigs(
 function createAllFormats(
   opts: NormalizedOpts,
   input: string
-): [TsdxOptions, ...TsdxOptions[]] {
+): [TSDXOptions, ...TSDXOptions[]] {
   return [
     opts.format.includes('cjs') && {
       ...opts,
@@ -85,5 +85,5 @@ function createAllFormats(
       env: 'production',
       input,
     },
-  ].filter(Boolean) as [TsdxOptions, ...TsdxOptions[]];
+  ].filter(Boolean) as [TSDXOptions, ...TSDXOptions[]];
 }

--- a/src/createBuildConfigs.ts
+++ b/src/createBuildConfigs.ts
@@ -1,9 +1,14 @@
-import { RollupOptions, OutputOptions } from 'rollup';
+import { RollupOptions } from 'rollup';
 import * as fs from 'fs-extra';
 import { concatAllArray } from 'jpjs';
 
 import { paths } from './constants';
-import { TSDXOptions, AtLeastOneTSDXOptions, NormalizedOpts } from './types';
+import {
+  TSDXOptions,
+  AtLeastOneTSDXOptions,
+  NormalizedOpts,
+  RollupOptionsWithOutput,
+} from './types';
 
 import { createRollupConfig } from './createRollupConfig';
 
@@ -20,7 +25,7 @@ if (fs.existsSync(paths.appConfig)) {
 
 export async function createBuildConfigs(
   opts: NormalizedOpts
-): Promise<Array<RollupOptions & { output: OutputOptions }>> {
+): Promise<RollupOptionsWithOutput[]> {
   const allInputs = concatAllArray(
     opts.input.map((input: string) =>
       createAllFormats(opts, input).map(

--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -1,6 +1,6 @@
 import { safeVariableName, safePackageName, external } from './utils';
 import { paths } from './constants';
-import { RollupOptions } from 'rollup';
+import { RollupOptions, Plugin } from 'rollup';
 import { terser } from 'rollup-plugin-terser';
 import { DEFAULT_EXTENSIONS as DEFAULT_BABEL_EXTENSIONS } from '@babel/core';
 import commonjs from '@rollup/plugin-commonjs';
@@ -213,6 +213,6 @@ export async function createRollupConfig(
           toplevel: opts.format === 'cjs',
           warnings: true,
         }),
-    ],
+    ].filter(Boolean) as Plugin[],
   };
 }

--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -14,8 +14,8 @@ import typescript from 'rollup-plugin-typescript2';
 import ts from 'typescript';
 
 import { extractErrors } from './errors/extractErrors';
-import { babelPluginTsdx } from './babelPluginTsdx';
-import { TsdxOptions } from './types';
+import { babelPluginTSDX } from './babelPluginTSDX';
+import { TSDXOptions } from './types';
 
 const errorCodeOpts = {
   errorMapFilePath: paths.appErrorsJson,
@@ -25,7 +25,7 @@ const errorCodeOpts = {
 let shebang: any = {};
 
 export async function createRollupConfig(
-  opts: TsdxOptions,
+  opts: TSDXOptions,
   outputNum: number
 ): Promise<RollupOptions> {
   const findAndRecordErrorCodes = await extractErrors({
@@ -71,7 +71,7 @@ export async function createRollupConfig(
     // Rollup has treeshaking by default, but we can optimize it further...
     treeshake: {
       // We assume reading a property of an object never has side-effects.
-      // This means tsdx WILL remove getters and setters defined directly on objects.
+      // This means TSDX WILL remove getters and setters defined directly on objects.
       // Any getters or setters defined on classes will not be effected.
       //
       // @example
@@ -184,7 +184,7 @@ export async function createRollupConfig(
         check: !opts.transpileOnly && outputNum === 0,
         useTsconfigDeclarationDir: Boolean(tsCompilerOptions?.declarationDir),
       }),
-      babelPluginTsdx({
+      babelPluginTSDX({
         exclude: 'node_modules/**',
         extensions: [...DEFAULT_BABEL_EXTENSIONS, 'ts', 'tsx'],
         passPerPreset: true,

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -2,17 +2,4 @@ declare module 'asyncro'; // doesn't have types (unmerged 2+ year old PR: https:
 declare module 'enquirer'; // doesn't have types for Input or Select
 declare module 'jpjs'; // doesn't ship types (written in TS though)
 declare module 'tiny-glob/sync'; // /sync isn't typed (but maybe we can use async?)
-
-// Patch Babel
-// @see line 226 of https://unpkg.com/@babel/core@7.4.4/lib/index.js
-declare module '@babel/core' {
-  export const DEFAULT_EXTENSIONS: string[];
-  export function createConfigItem(boop: any[], options: any): any[];
-}
-
-// Rollup plugins
-declare module 'rollup-plugin-terser';
-declare module '@babel/traverse';
-declare module '@babel/helper-module-imports';
-
-declare module 'lodash.merge';
+declare module '@babel/helper-module-imports'; // doesn't have types

--- a/src/errors/extractErrors.ts
+++ b/src/errors/extractErrors.ts
@@ -37,7 +37,9 @@ export async function extractErrors(opts: any) {
   }
 
   if (!opts.name || !('name' in opts)) {
-    throw new Error('Missing options. Ensure you pass --name flag to tsdx');
+    throw new Error(
+      'Missing options. Ensure you pass --name flag to `tsdx build`'
+    );
   }
 
   const errorMapFilePath = opts.errorMapFilePath;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,14 +2,7 @@
 
 import sade from 'sade';
 import glob from 'tiny-glob/sync';
-import {
-  rollup,
-  watch,
-  RollupOptions,
-  OutputOptions,
-  RollupWatchOptions,
-  WatcherOptions,
-} from 'rollup';
+import { rollup, watch, RollupWatchOptions, WatcherOptions } from 'rollup';
 import asyncro from 'asyncro';
 import chalk from 'chalk';
 import * as fs from 'fs-extra';
@@ -42,6 +35,7 @@ import {
   BuildOpts,
   AtLeastOneModuleFormat,
   NormalizedOpts,
+  RollupOptionsWithOutput,
 } from './types';
 import { createProgressEstimator } from './createProgressEstimator';
 import { templates } from './templates';
@@ -393,13 +387,10 @@ prog
     }
     try {
       const promise = asyncro
-        .map(
-          buildConfigs,
-          async (inputOptions: RollupOptions & { output: OutputOptions }) => {
-            let bundle = await rollup(inputOptions);
-            await bundle.write(inputOptions.output);
-          }
-        )
+        .map(buildConfigs, async (inputOptions: RollupOptionsWithOutput) => {
+          let bundle = await rollup(inputOptions);
+          await bundle.write(inputOptions.output);
+        })
         .catch((e: any) => {
           throw e;
         })

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ import {
   PackageJson,
   WatchOpts,
   BuildOpts,
-  ModuleFormat,
+  AtLeastOneModuleFormat,
   NormalizedOpts,
 } from './types';
 import { createProgressEstimator } from './createProgressEstimator';
@@ -424,7 +424,7 @@ async function normalizeOpts(opts: WatchOpts): Promise<NormalizedOpts> {
         return 'esm';
       }
       return format;
-    }) as [ModuleFormat, ...ModuleFormat[]],
+    }) as AtLeastOneModuleFormat,
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ interface SharedOpts {
 }
 
 export type ModuleFormat = 'cjs' | 'umd' | 'esm' | 'system';
+export type AtLeastOneModuleFormat = [ModuleFormat, ...ModuleFormat[]];
 
 export interface BuildOpts extends SharedOpts {
   name?: string;
@@ -29,7 +30,7 @@ export interface NormalizedOpts
   extends Omit<WatchOpts, 'name' | 'input' | 'format'> {
   name: string;
   input: string[];
-  format: [ModuleFormat, ...ModuleFormat[]];
+  format: AtLeastOneModuleFormat;
 }
 
 export interface TSDXOptions extends SharedOpts {
@@ -48,6 +49,7 @@ export interface TSDXOptions extends SharedOpts {
   // Only transpile, do not type check (makes compilation faster)
   transpileOnly?: boolean;
 }
+export type AtLeastOneTSDXOptions = [TSDXOptions, ...TSDXOptions[]];
 
 export interface PackageJson {
   name: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,7 @@ export interface NormalizedOpts
   format: [ModuleFormat, ...ModuleFormat[]];
 }
 
-export interface TsdxOptions extends SharedOpts {
+export interface TSDXOptions extends SharedOpts {
   // Name of package
   name: string;
   // path to file

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,3 +66,7 @@ export interface PackageJson {
 }
 
 export type RollupOptionsWithOutput = RollupOptions & { output: OutputOptions };
+
+export interface TSDXConfig {
+  rollup: (config: RollupOptions, options: TSDXOptions) => RollupOptions;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { RollupOptions, OutputOptions } from 'rollup';
+
 interface SharedOpts {
   // JS target
   target: 'node' | 'browser';
@@ -62,3 +64,5 @@ export interface PackageJson {
     node?: string;
   };
 }
+
+export type RollupOptionsWithOutput = RollupOptions & { output: OutputOptions };

--- a/templates/basic/README.md
+++ b/templates/basic/README.md
@@ -68,7 +68,7 @@ Two actions are added by default:
 
 ## Optimizations
 
-Please see the main `tsdx` [optimizations docs](https://github.com/palmerhq/tsdx#optimizations). In particular, know that you can take advantage of development-only optimizations:
+Please see the main TSDX [optimizations docs](https://github.com/palmerhq/tsdx#optimizations). In particular, know that you can take advantage of development-only optimizations:
 
 ```js
 // ./types/index.d.ts

--- a/templates/react-with-storybook/README.md
+++ b/templates/react-with-storybook/README.md
@@ -108,7 +108,7 @@ Two actions are added by default:
 
 ## Optimizations
 
-Please see the main `tsdx` [optimizations docs](https://github.com/palmerhq/tsdx#optimizations). In particular, know that you can take advantage of development-only optimizations:
+Please see the main TSDX [optimizations docs](https://github.com/palmerhq/tsdx#optimizations). In particular, know that you can take advantage of development-only optimizations:
 
 ```js
 // ./types/index.d.ts

--- a/templates/react/README.md
+++ b/templates/react/README.md
@@ -87,7 +87,7 @@ Two actions are added by default:
 
 ## Optimizations
 
-Please see the main `tsdx` [optimizations docs](https://github.com/palmerhq/tsdx#optimizations). In particular, know that you can take advantage of development-only optimizations:
+Please see the main TSDX [optimizations docs](https://github.com/palmerhq/tsdx#optimizations). In particular, know that you can take advantage of development-only optimizations:
 
 ```js
 // ./types/index.d.ts

--- a/website/pages/customization.md
+++ b/website/pages/customization.md
@@ -20,7 +20,7 @@ module.exports = {
 The `options` object contains the following:
 
 ```tsx
-export interface TsdxOptions {
+export interface TSDXOptions {
   // path to file
   input: string;
   // Name of package
@@ -73,7 +73,7 @@ module.exports = {
 
 ## Babel
 
-You can add your own `.babelrc` to the root of your project and TSDX will **merge** it with [its own Babel transforms](./src/babelPluginTsdx.ts) (which are mostly for optimization), putting any new presets and plugins at the end of its list.
+You can add your own `.babelrc` to the root of your project and TSDX will **merge** it with [its own Babel transforms](./src/babelPluginTSDX.ts) (which are mostly for optimization), putting any new presets and plugins at the end of its list.
 
 ## Jest
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1174,10 +1174,10 @@
     traverse "^0.6.6"
     unified "^6.1.6"
 
-"@types/babel__core@^7.1.7":
-  version "7.1.7"
-  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.7.tgz#1dacad8840364a57c98d0dd4855c6dd3752c6b89"
-  integrity sha512-RL62NqSFPCDK2FM1pSDH0scHpJvsXtZNiYlMB73DgPBaG1E38ZYVL+ei5EkWRbr+KC4YNiAUNBnRj+bgwpgjMw==
+"@types/babel__core@^7.1.10", "@types/babel__core@^7.1.7":
+  version "7.1.10"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.10.tgz#ca58fc195dd9734e77e57c6f2df565623636ab40"
+  integrity sha512-x8OM8XzITIMyiwl5Vmo2B1cR1S1Ipkyv4mdlbJjMa1lmuKvKY9FrBbEANIaMlnWn5Rf7uO+rC/VgYabNkE17Hw==
   dependencies:
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"
@@ -1200,10 +1200,10 @@
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"
 
-"@types/babel__traverse@*", "@types/babel__traverse@^7.0.6":
-  version "7.0.8"
-  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.0.8.tgz#479a4ee3e291a403a1096106013ec22cf9b64012"
-  integrity sha512-yGeB2dHEdvxjP0y4UbRtQaSkXJ9649fYCmIdRoul5kfAoGCwxuCbMhag0k3RPfnuh9kPGm8x89btcfDEXdVWGw==
+"@types/babel__traverse@*", "@types/babel__traverse@^7.0.15", "@types/babel__traverse@^7.0.6":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.0.15.tgz#db9e4238931eb69ef8aab0ad6523d4d4caa39d03"
+  integrity sha512-Pzh9O3sTK8V6I1olsXpCfj2k/ygO2q1X0vhhnDrEQyYLHZesWz+zMZMVcwXLCYf0U36EtmyYaFGPfXlTtDHe3A==
   dependencies:
     "@babel/types" "^7.3.0"
 
@@ -1314,10 +1314,17 @@
   dependencies:
     "@types/node" "*"
 
-"@types/lodash@^4.14.161":
-  version "4.14.161"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.161.tgz#a21ca0777dabc6e4f44f3d07f37b765f54188b18"
-  integrity sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==
+"@types/lodash.merge@^4.6.6":
+  version "4.6.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.merge/-/lodash.merge-4.6.6.tgz#b84b403c1d31bc42d51772d1cd5557fa008cd3d6"
+  integrity sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*", "@types/lodash@^4.14.161":
+  version "4.14.162"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.162.tgz#65d78c397e0d883f44afbf1f7ba9867022411470"
+  integrity sha512-alvcho1kRUnnD1Gcl4J+hK0eencvzq9rmzvFPRmP5rPHx9VVsJj6bKLTATPVf9ktgv4ujzh7T+XWKp+jhuODig==
 
 "@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.3"


### PR DESCRIPTION
## Description

### Commits

#### types: add remaining external typings
- added @types/babel__core, @types/babel__traverse, and
  @types/lodash.merge and removed their declarations in env.d.ts
  - also removed rollup-plugin-terser's declaration there because it
    has types built-in
  - remaining actually don't have types per in-line comments

- this improved type-checking allowed TS to do stricter checks and so
  exposed a few type errors that were fixed as well
  - @rollup/plugin-babel depends on @types/babel__core as well, so the
    declaration here had previously overridden it
    - `custom` had to be augmented as it's not an option of
      `@rollup/plugin-babel`
    - `passPerPreset` did too though... it's not in `@types/babel__core`
      but it is a (deprecated) Babel option
      - logs seemed to show it was `false` regardless of what was
        passed in though...
  - Rollup's `plugins` now started complaining that `false` wasn't a
    valid Plugin either, so added a `.filter(Boolean)` but that didn't
    fully fix it so had to type-cast

#### refactor/fix: consistently use capital TSDX everywhere
- Jared had asked in a review comment back in December to consistently
  use capital TSDX (not `tsdx`) so this establishes that throughout the
  rest of the codebase
  - I don't think any of these lines/files/variables were written by me,
    so I'm just fixing up existing ones

- this came up as I was refactoring typings, so wanted to make sure
  everything was consistent as I went

#### refactor/types: explicitly name "at least one" types

#### refactor/types: add a type for RollupOptionsWithOutput

#### refactor/types: add a TSDXConfig type
- another PR by a contributor exposes the types for `tsdx.config.js` in
  order to be used in JSDoc, so this makes it so only a single type is
  needed and exported

## Tags

- Using capital TSDX instead of `tsdx`, "tsdx", etc was requested in https://github.com/formium/tsdx/pull/400#discussion_r361858698. Maybe in an earlier issue/PR too, but I couldn't find or remember it.
- The "at least one" type confusion was in https://github.com/formium/tsdx/pull/401#discussion_r361774071
- `TSDXConfig` type is pretty much just to simplify #823 

## Review Notes

The `passPerPreset` augmentation for `@rollup/plugin-babel` / `@types/babel__core` that is mentioned above is pretty confusing. I decided to leave it as is for now so as to potentially change anything, but my logs seem to show it isn't used 😕 🤔  :

<details>
  <summary>Babel log output:</summary>

```ts
PartialConfig {
  options:
   { sourceMaps: true,
     caller:
      { name: '@rollup/plugin-babel',
        supportsStaticESM: true,
        supportsDynamicImport: true,
        supportsTopLevelAwait: true },
     filename:
      '[redacted]/tsdx/stage-build-default/src/syntax/jsx-import/JSX-B.jsx',
     babelrc: false,
     configFile: false,
     passPerPreset: false,
     envName: 'test',
     cwd:
      '[redacted]/tsdx/stage-build-default',
     root:
      '[redacted]/tsdx/stage-build-default',
     plugins: [],
     presets: [] },
  babelignore: undefined,
  babelrc: undefined,
  config: undefined }
{ sourceMaps: true,
  caller:
   { name: '@rollup/plugin-babel',
     supportsStaticESM: true,
     supportsDynamicImport: true,
     supportsTopLevelAwait: true },
  filename:
   '[redacted]/tsdx/stage-build-default/src/syntax/jsx-import/JSX-B.jsx',
  babelrc: false,
  configFile: false,
  passPerPreset: false,
  envName: 'test',
  cwd:
   '[redacted]/tsdx/stage-build-default',
  root:
   '[redacted]/tsdx/stage-build-default',
  plugins:
   [ ConfigItem {
       value: [Function],
       options: {},
       dirname:
        '[redacted]/tsdx/stage-build-default',
       name: undefined,
       file: [Object] },
     ConfigItem {
       value: [Function: _default],
       options: {},
       dirname:
        '[redacted]/tsdx/stage-build-default',
       name: undefined,
       file: [Object] },
     ConfigItem {
       value: [Function],
       options: {},
       dirname:
        '[redacted]/tsdx/stage-build-default',
       name: undefined,
       file: [Object] },
     ConfigItem {
       value: [Function],
       options: [Object],
       dirname:
        '[redacted]/tsdx/stage-build-default',
       name: undefined,
       file: [Object] },
     ConfigItem {
       value: [Function],
       options: [Object],
       dirname:
        '[redacted]/tsdx/stage-build-default',
       name: undefined,
       file: [Object] } ],
  presets:
   [ ConfigItem {
       value: [Function],
       options: [Object],
       dirname:
        '[redacted]/tsdx/stage-build-default',
       name: undefined,
       file: [Object] } ] }
PartialConfig {
  options:
   { sourceMaps: true,
     caller:
      { name: '@rollup/plugin-babel',
        supportsStaticESM: true,
        supportsDynamicImport: true,
        supportsTopLevelAwait: true },
     filename:
      '[redacted]/tsdx/stage-build-default/src/syntax/jsx-import/JSX-B.jsx',
     babelrc: false,
     configFile: false,
     passPerPreset: false,
     envName: 'test',
     cwd:
      '[redacted]/tsdx/stage-build-default',
     root:
      '[redacted]/tsdx/stage-build-default',
     plugins: [],
     presets: [] },
  babelignore: undefined,
  babelrc: undefined,
  config: undefined }
```
</details>