### PR TITLE
change: by default lint all dirs, not just src and test

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -540,17 +540,17 @@ prog
 prog
   .command('lint')
   .describe('Run eslint with Prettier')
-  .example('lint src test')
+  .example('lint ./')
   .option('--fix', 'Fixes fixable errors and warnings')
-  .example('lint src test --fix')
+  .example('lint ./ --fix')
   .option('--ignore-pattern', 'Ignore a pattern')
-  .example('lint src test --ignore-pattern test/foobar.ts')
+  .example('lint ./ --ignore-pattern test/foobar.ts')
   .option(
     '--max-warnings',
     'Exits with non-zero error code if number of warnings exceed this number',
     Infinity
   )
-  .example('lint src test --max-warnings 10')
+  .example('lint ./ --max-warnings 10')
   .option('--write-file', 'Write the config file locally')
   .example('lint --write-file')
   .option('--report-file', 'Write JSON report to file locally')
@@ -565,11 +565,11 @@ prog
       _: string[];
     }) => {
       if (opts['_'].length === 0 && !opts['write-file']) {
-        const defaultInputs = ['src', 'test'].filter(fs.existsSync);
+        const defaultInputs = ['./'];
         opts['_'] = defaultInputs;
         console.log(
           chalk.yellow(
-            `Defaulting to "tsdx lint ${defaultInputs.join(' ')}"`,
+            `Defaulting to "tsdx lint ${defaultInputs}"`,
             '\nYou can override this in the package.json scripts, like "lint": "tsdx lint src otherDir"'
           )
         );


### PR DESCRIPTION
## Description

- BREAKING: change the default lint args from 'src test' to './'

- this is the same arg that's used internally and there isn't really a
  reason to skip some files arbitrarily; it's best practice to lint
  everything
- this also lines up with changes to make `tsc` type-check all files,
  instead of just 'src' and 'types'

## Tags

- I made the same change internally in #648
- Goes along with `tsc` changes mentioned in https://github.com/formium/tsdx/issues/871#issuecomment-695822562 et al

## Notes

This is a breaking change. While it probably affects few users due to the fact that it gives a warning when nothing is specified, it is still breaking. Would make sense to add in [v0.16.0](https://github.com/formium/tsdx/milestone/4) to go with the other ESLint / formatting changes.