### PR TITLE
Add option to not show progress animations in logs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -382,11 +382,19 @@ prog
   .example(
     'build --extractErrors=https://reactjs.org/docs/error-decoder.html?invariant='
   )
+  .option('--noProgress', "Don't show progress animations")
+  .example('build --noProgress')
   .action(async (dirtyOpts: BuildOpts) => {
     const opts = await normalizeOpts(dirtyOpts);
     const buildConfigs = await createBuildConfigs(opts);
     await cleanDistFolder();
-    const logger = await createProgressEstimator();
+    const progress =
+      process.stdout.isTTY && !process.env.CI && !opts.noProgress;
+    const logger = progress
+      ? await createProgressEstimator()
+      : (_promise: unknown, message: string) => {
+          console.log(message);
+        };
     if (opts.format.includes('cjs')) {
       const promise = writeCjsEntryFile(opts.name).catch(logError);
       logger(promise, 'Creating entry file');

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,8 @@ interface SharedOpts {
   tsconfig?: string;
   // Is error extraction running?
   extractErrors?: boolean;
+  // Should omit progress animations?
+  noProgress?: boolean;
 }
 
 export type ModuleFormat = 'cjs' | 'umd' | 'esm' | 'system';


### PR DESCRIPTION
Fixes https://github.com/formium/tsdx/issues/689. 

Adds a --noProgress flag (based on lerna's `--no-progress`, but made camelCase to match existing flags). When used, the `progress-estimator` logger is replaced by a simple `console.log` of the message. The progress animations will also be removed when the environment is not a TTY and when running in CI.

Thanks for a great tool, and let me know if there's anything I can do to improve this PR.