### PR TITLE
feature: shebang banner

### DIFF
--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -45,6 +45,7 @@ export async function createRollupConfig(
   ]
     .filter(Boolean)
     .join('.');
+  const banner = opts.bin ? `#!/usr/bin/env node` : undefined;
 
   const tsconfigPath = opts.tsconfig || paths.tsconfigJson;
   // borrowed from https://github.com/facebook/create-react-app/pull/7248
@@ -100,6 +101,7 @@ export async function createRollupConfig(
       freeze: false,
       // Respect tsconfig esModuleInterop when setting __esModule.
       esModule: Boolean(tsCompilerOptions?.esModuleInterop),
+      banner,
       name: opts.name || safeVariableName(opts.name),
       sourcemap: true,
       globals: { react: 'React', 'react-native': 'ReactNative' },

--- a/src/index.ts
+++ b/src/index.ts
@@ -279,6 +279,8 @@ prog
   .example('watch --onFailure "The build failed!"')
   .option('--transpileOnly', 'Skip type checking')
   .example('watch --transpileOnly')
+  .option('--bin', 'Specify if shebang is added to build')
+  .example('build --bin')
   .option('--extractErrors', 'Extract invariant errors to ./errors/codes.json.')
   .example('watch --extractErrors')
   .action(async (dirtyOpts: WatchOpts) => {
@@ -375,6 +377,8 @@ prog
   .example('build --tsconfig ./tsconfig.foo.json')
   .option('--transpileOnly', 'Skip type checking')
   .example('build --transpileOnly')
+  .option('--bin', 'Specify if shebang is added to build')
+  .example('build --bin')
   .option(
     '--extractErrors',
     'Extract errors to ./errors/codes.json and provide a url for decoding.'
@@ -417,6 +421,7 @@ prog
 async function normalizeOpts(opts: WatchOpts): Promise<NormalizedOpts> {
   return {
     ...opts,
+    bin: Boolean(opts.bin || appPackageJson.bin),
     name: opts.name || appPackageJson.name,
     input: await getInputs(opts.entry, appPackageJson.source),
     format: opts.format.split(',').map((format: string) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,8 @@ interface SharedOpts {
   tsconfig?: string;
   // Is error extraction running?
   extractErrors?: boolean;
+  // Is executive?
+  bin?: boolean;
 }
 
 export type ModuleFormat = 'cjs' | 'umd' | 'esm' | 'system';
@@ -52,6 +54,7 @@ export interface TsdxOptions extends SharedOpts {
 export interface PackageJson {
   name: string;
   source?: string;
+  bin?: string | { [binary: string]: string };
   jest?: any;
   eslint?: any;
   dependencies?: { [packageName: string]: string };

--- a/test/e2e/fixtures/build-default/package.json
+++ b/test/e2e/fixtures/build-default/package.json
@@ -1,4 +1,5 @@
 {
+  "bin": "dist/index.js",
   "scripts": {
     "build": "tsdx build"
   },

--- a/test/e2e/tsdx-build-default.test.ts
+++ b/test/e2e/tsdx-build-default.test.ts
@@ -41,6 +41,13 @@ describe('tsdx build :: zero-config defaults', () => {
     expect(output.code).toBe(0);
   });
 
+  it('should add shebang', async () => {
+    const output = execWithCache('node ../dist/index.js build');
+    expect(output.code).toBe(0);
+    const matched = grep(/#!\/usr\/bin\/env/, ['dist/build-default.*.js']);
+    expect(matched).toBeTruthy();
+  });
+
   it('should create the library correctly', async () => {
     const output = execWithCache('node ../dist/index.js build');
 


### PR DESCRIPTION
Use `rolloup.output.banner` to add shebang header into bundle. Resolves #338 

### Changes

* add `--bin` flag
* if `bin` is specified in package.json, output with shebang header