### PR TITLE
feat: Add .storybook to lint and make configs typescript files

### DIFF
--- a/src/templates/react-with-storybook.ts
+++ b/src/templates/react-with-storybook.ts
@@ -21,6 +21,7 @@ const storybookTemplate: Template = {
       ...reactTemplate.packageJson.scripts,
       storybook: 'start-storybook -p 6006',
       'build-storybook': 'build-storybook',
+      lint: 'tsdx lint src test .storybook',
     } as PackageJson['scripts'],
   },
 };

--- a/templates/react-with-storybook/.storybook/main.ts
+++ b/templates/react-with-storybook/.storybook/main.ts
@@ -4,5 +4,5 @@ module.exports = {
   // https://storybook.js.org/docs/react/configure/typescript#mainjs-configuration
   typescript: {
     check: true, // type-check stories during Storybook build
-  }
+  },
 };

--- a/templates/react-with-storybook/.storybook/preview.ts
+++ b/templates/react-with-storybook/.storybook/preview.ts
@@ -1,5 +1,7 @@
+import { Parameters } from "@storybook/react";
+
 // https://storybook.js.org/docs/react/writing-stories/parameters#global-parameters
-export const parameters = {
+export const parameters: Parameters = {
   // https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args
   actions: { argTypesRegex: '^on.*' },
 };


### PR DESCRIPTION
Making `preview.js` a typescript file allows us to get types for Parameters.

I couldn't find types for what the `main.js` file exports though.