### PR TITLE
fix(template): fixes typo in react template README

### DIFF
--- a/templates/react/README.md
+++ b/templates/react/README.md
@@ -42,7 +42,7 @@ Jest tests are set up to run with `npm test` or `yarn test`.
 
 ### Bundle analysis
 
-Calculates the real cost of your library using [size-limit](https://github.com/ai/size-limit) with `npm run size` and visulize it with `npm run analyze`.
+Calculates the real cost of your library using [size-limit](https://github.com/ai/size-limit) with `npm run size` and visualize it with `npm run analyze`.
 
 #### Setup Files
 


### PR DESCRIPTION
The other two templates are correct