### PR TITLE
fix: should respect user's typescript, tslib

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,9 +94,7 @@
     "semver": "^7.1.1",
     "shelljs": "^0.8.3",
     "tiny-glob": "^0.2.6",
-    "ts-jest": "^25.3.1",
-    "tslib": "^1.9.3",
-    "typescript": "^3.7.3"
+    "ts-jest": "^25.3.1"
   },
   "devDependencies": {
     "@types/eslint": "^6.1.2",
@@ -123,7 +121,13 @@
     "styled-components": "^5.0.1",
     "tiny-invariant": "^1.1.0",
     "tiny-warning": "^1.0.3",
+    "tslib": "^1.9.3",
+    "typescript": "^3.7.3",
     "yarn-deduplicate": "^2.1.1"
+  },
+  "peerDependencies": {
+    "tslib": "^1.9.3 || ^2.0.0",
+    "typescript": "^3.7.3 || ^4.0.0"
   },
   "husky": {
     "hooks": {

--- a/src/createRollupConfig.ts
+++ b/src/createRollupConfig.ts
@@ -11,7 +11,6 @@ import resolve, {
 } from '@rollup/plugin-node-resolve';
 import sourceMaps from 'rollup-plugin-sourcemaps';
 import typescript from 'rollup-plugin-typescript2';
-import ts from 'typescript';
 
 import { extractErrors } from './errors/extractErrors';
 import { babelPluginTsdx } from './babelPluginTsdx';
@@ -23,6 +22,22 @@ const errorCodeOpts = {
 
 // shebang cache map thing because the transform only gets run once
 let shebang: any = {};
+let ts: typeof import('typescript');
+try {
+  ts = require('typescript');
+} catch (error) {
+  throw new Error(
+    `The module "typescript" was not found. tsdx requires that you include it in "dependencies" of your "package.json". To add it, run "npm install typescript"`
+  );
+}
+
+try {
+  require.resolve('tslib');
+} catch (error) {
+  console.warn(
+    `The module "tslib" was not found. We use it to reduce your bundle size.`
+  );
+}
 
 export async function createRollupConfig(
   opts: TsdxOptions,


### PR DESCRIPTION
Shortly, typescript and tslib should always be a member of `peerDependencies`, rather than `dependencies`. Otherwise, tsdx user never use their own tslib and typescript due to [nodejs module resolution rules](https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders).

## reproduce

1. install

```plaintext
npx tsdx create tsdx-demo
# choose one template
cd tsdx-demo
```

2. add some typescript v4 language feature in src/\*.ts file, for example, in `src/index.ts`：

```typescript
// src/index.ts
type Method = 'GET'
// Lowercase is typescript v4 language feature
export function oops(method: Lowercase<Method>) {
  return method
}
```

3. build

```bash
yarn build
# semantic error TS2304: Cannot find name 'Lowercase'.
```

But [Lowercase](https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html#lowercasestringtype) actually is typescript `Intrinsic String Manipulation Types` in v4

4. check all dependencies

```bash
// yarn v1.2.x
yarn list --pattern typescript
```

```plaintext
 yarn list --pattern typescript
 yarn list v1.22.5
 ├─ @typescript-eslint/eslint-plugin@2.34.0
 ├─ @typescript-eslint/experimental-utils@2.34.0
 ├─ @typescript-eslint/parser@2.34.0
 ├─ @typescript-eslint/typescript-estree@2.34.0
 ├─ rollup-plugin-typescript2@0.27.3
 ├─ tsdx@0.14.1
 │  └─ typescript@3.9.9
 └─ typescript@4.2.3
```

## why

Everything go back to normal when I delete typescript dir in `<PROJECT_ROOT>/node_modules/tsdx/node_modules/typescript`.  I wrote some code only supported by typescript v4, but tsdx only require typescript v3x.

**tsdx always require tsdx's typescript and tslib, rather than user's own version due to [nodejs module resolution rules](https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders).**

[This code](https://github.com/formium/tsdx/blob/v0.14.1/src/createRollupConfig.ts#L14) always requires typescript from tsdx's dependencies, rather than project's dependencies, [that code](https://github.com/formium/tsdx/blob/v0.14.1/src/templates/basic.ts#L9) typescript version **never works**!!

### conclusion

typescript should always be a member of peerDependencies. tslib too.

## solution

1. move typescript, tslib into peerDependencies field

1. throw importation error when typescript isn't installed, but tslib only throws a warning.

### for tsdx template user

Nothing needs to be done (because tsdx template will install typescript and tslib automatically)

### for standalone user (without tsdx template)

1. should always install typescript, tslib manually.