### PR TITLE
fix: Do not commit parcel cache for parcel 2

### DIFF
--- a/templates/react/gitignore
+++ b/templates/react/gitignore
@@ -3,3 +3,4 @@
 node_modules
 .cache
 dist
+.parcel-cache


### PR DESCRIPTION
Parcel 2 is in development, and `.cache` is now called `.parcel-cache`.