### PR TITLE
Fixed types in template.d.ts

### DIFF
--- a/src/templates/template.d.ts
+++ b/src/templates/template.d.ts
@@ -3,5 +3,5 @@ import { PackageJson } from 'type-fest';
 interface Template {
   dependencies: string[];
   name: string;
-  packageJson: PackageJson;
+  packageJson: PackageJson & { husky: any; prettier: any };
 }


### PR DESCRIPTION
Fixed types in template.d.ts, because the data has keys which doesn't exist in type.