### PR TITLE
upgrade to parcel-bundler^1.12.5 from parcel^1.12.3 in templates

### DIFF
--- a/templates/react-with-storybook/example/package.json
+++ b/templates/react-with-storybook/example/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@types/react": "^16.9.11",
     "@types/react-dom": "^16.8.4",
-    "parcel": "^1.12.3",
+    "parcel-bundler": "^1.12.5",
     "typescript": "^3.4.5"
   }
 }

--- a/templates/react/example/package.json
+++ b/templates/react/example/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@types/react": "^16.9.11",
     "@types/react-dom": "^16.8.4",
-    "parcel": "^1.12.3",
+    "parcel-bundler": "^1.12.5",
     "typescript": "^3.4.5"
   }
 }


### PR DESCRIPTION
This will fix #980.

Currently, in the two template projects (react and react-with-storybook), you will encounter "Invalid Version: undefined" errors when you type `yarn start` in the example directories.

This is due to specifying "parcel": "^1.12.3" in package.json and upgrading to 1.12.5 will fix the problem.

However, v1.12.5 exists only in [parcel-bundler package](https://www.npmjs.com/package/parcel-bundler), so I change "parcel": "^1.12.3" to "parcel-bundler": "^1.12.5".

In addition, upgrading to parcel v2 beta will break hot module reloading (https://github.com/formium/tsdx/issues/980#issuecomment-798875545), so I decided to use not parcel v2 but parcel-bundler.

